### PR TITLE
Allow for a Row Key function to be passed to the sinks

### DIFF
--- a/src/Serilog.Sinks.AzureTableStorage/LoggerConfigurationAzureTableStorageExtensions.cs
+++ b/src/Serilog.Sinks.AzureTableStorage/LoggerConfigurationAzureTableStorageExtensions.cs
@@ -36,7 +36,7 @@ namespace Serilog
         /// A reasonable default time to wait between checking for event batches.
         /// </summary>
         public static readonly TimeSpan DefaultPeriod = TimeSpan.FromSeconds(2);
-
+        
 		/// <summary>
         /// Adds a sink that writes log events as records in the 'LogEventEntity' Azure Table Storage table in the given storage account.
         /// </summary>

--- a/src/Serilog.Sinks.AzureTableStorage/LoggerConfigurationAzureTableStorageWithPropertiesExtensions.cs
+++ b/src/Serilog.Sinks.AzureTableStorage/LoggerConfigurationAzureTableStorageWithPropertiesExtensions.cs
@@ -54,6 +54,7 @@ namespace Serilog
 		/// <param name="batchPostingLimit">The maximum number of events to post in a single batch.</param>
 		/// <param name="period">The time to wait between checking for event batches.</param>
 		/// <param name="additionalRowKeyPostfix">Additional postfix string that will be appended to row keys</param>
+        /// <param name="rowKeyFunc">Function to generate a row key</param>
 		/// <returns>Logger configuration, allowing configuration to continue.</returns>
 		/// <exception cref="ArgumentNullException">A required parameter is null.</exception>
 		public static LoggerConfiguration AzureTableStorageWithProperties(
@@ -65,14 +66,15 @@ namespace Serilog
 			bool writeInBatches = false,
 			TimeSpan? period = null,
 			int? batchPostingLimit = null,
-			string additionalRowKeyPostfix = null)
+            string additionalRowKeyPostfix = null,
+            Func<LogEvent, string, string> rowKeyFunc = null)
 		{
 			if (loggerConfiguration == null) throw new ArgumentNullException("loggerConfiguration");
 			if (storageAccount == null) throw new ArgumentNullException("storageAccount");
 
 			var sink = writeInBatches ?
-				(ILogEventSink)new AzureBatchingTableStorageWithPropertiesSink(storageAccount, formatProvider, batchPostingLimit ?? DefaultBatchPostingLimit, period ?? DefaultPeriod, storageTableName, additionalRowKeyPostfix) :
-				new AzureTableStorageWithPropertiesSink(storageAccount, formatProvider, storageTableName, additionalRowKeyPostfix);
+				(ILogEventSink)new AzureBatchingTableStorageWithPropertiesSink(storageAccount, formatProvider, batchPostingLimit ?? DefaultBatchPostingLimit, period ?? DefaultPeriod, storageTableName, additionalRowKeyPostfix, rowKeyFunc) :
+				new AzureTableStorageWithPropertiesSink(storageAccount, formatProvider, storageTableName, additionalRowKeyPostfix, rowKeyFunc);
 
 			return loggerConfiguration.Sink(sink, restrictedToMinimumLevel);
 		}
@@ -90,6 +92,7 @@ namespace Serilog
 		/// <param name="batchPostingLimit">The maximum number of events to post in a single batch.</param>
 		/// <param name="period">The time to wait between checking for event batches.</param>
 		/// <param name="additionalRowKeyPostfix">Additional postfix string that will be appended to row keys</param>
+        /// <param name="rowKeyFunc">Function to generate a row key</param>
 		/// <returns>Logger configuration, allowing configuration to continue.</returns>
 		/// <exception cref="ArgumentNullException">A required parameter is null.</exception>
 		public static LoggerConfiguration AzureTableStorageWithProperties(
@@ -101,12 +104,13 @@ namespace Serilog
 			bool writeInBatches = false,
 			TimeSpan? period = null,
 			int? batchPostingLimit = null,
-			string additionalRowKeyPostfix = null)
+            string additionalRowKeyPostfix = null,
+            Func<LogEvent, string, string> rowKeyFunc = null)
 		{
 			if (loggerConfiguration == null) throw new ArgumentNullException("loggerConfiguration");
 			if (String.IsNullOrEmpty(connectionString)) throw new ArgumentNullException("connectionString");
 			var storageAccount = CloudStorageAccount.Parse(connectionString);
-			return AzureTableStorageWithProperties(loggerConfiguration, storageAccount, restrictedToMinimumLevel, formatProvider, storageTableName, writeInBatches, period, batchPostingLimit, additionalRowKeyPostfix);
+			return AzureTableStorageWithProperties(loggerConfiguration, storageAccount, restrictedToMinimumLevel, formatProvider, storageTableName, writeInBatches, period, batchPostingLimit, additionalRowKeyPostfix, rowKeyFunc);
 		}
 	}
 }

--- a/src/Serilog.Sinks.AzureTableStorage/Sinks/AzureTableStorage/LogEventEntity.cs
+++ b/src/Serilog.Sinks.AzureTableStorage/Sinks/AzureTableStorage/LogEventEntity.cs
@@ -49,7 +49,7 @@ namespace Serilog.Sinks.AzureTableStorage
         {
             Timestamp = log.Timestamp.ToUniversalTime().DateTime;
             PartitionKey = string.Format("0{0}", partitionKey);
-            RowKey = GetValidRowKey(string.Format("{0}|{1}", log.Level, log.MessageTemplate.Text));
+            RowKey = GetValidRowKey(this, string.Format("{0}|{1}", log.Level, log.MessageTemplate.Text), 0);
             MessageTemplate = log.MessageTemplate.Text;
             Level = log.Level.ToString();
             Exception = log.Exception != null ? log.Exception.ToString() : null;
@@ -60,7 +60,7 @@ namespace Serilog.Sinks.AzureTableStorage
         }
 
         // http://msdn.microsoft.com/en-us/library/windowsazure/dd179338.aspx
-        static string GetValidRowKey(string rowKey)
+        internal static string GetValidRowKey(LogEventEntity entity, string rowKey, int batchRowId)
         {
             rowKey = RowKeyNotAllowedMatch.Replace(rowKey, "");
             return rowKey.Length > 1024 ? rowKey.Substring(0, 1024) : rowKey;


### PR DESCRIPTION
Allows the developer to pass a function to control the value of the RowKey, for example:

(Recommended by http://stackoverflow.com/questions/15195773/azure-table-storage-rowkey-design-for-ordered-data)

```
.WriteTo.AzureTableStorageWithProperties(storage, Serilog.Events.LogEventLevel.Information,
                storageTableName: "Serilog",
                rowKeyFunc: (evt, msg) =>
                {
                    return (DateTime.MaxValue.Ticks - DateTime.UtcNow.Ticks).ToString("d19");
                });
```

The non-properties enabled sinks don't yet have extension methods to pass the function in.
