### PR TITLE
Add Azure restricted key characters to Regex

### DIFF
--- a/src/Serilog.Sinks.AzureTableStorage/Sinks/AzureTableStorage/LogEventEntity.cs
+++ b/src/Serilog.Sinks.AzureTableStorage/Sinks/AzureTableStorage/LogEventEntity.cs
@@ -32,7 +32,7 @@ namespace Serilog.Sinks.AzureTableStorage
     /// </remarks>
     public class LogEventEntity : TableEntity
     {
-        static readonly Regex RowKeyNotAllowedMatch = new Regex(@"(\\|/|#|\?)");
+        static readonly Regex RowKeyNotAllowedMatch = new Regex(@"(\\|/|#|\?|[\x00-\x1f]|[\x7f-\x9f])");
 
         /// <summary>
         /// Default constructor for the Storage Client library to re-hydrate entities when querying.


### PR DESCRIPTION
Hello,

I met problems using EasyNetQ with Serilog Azure Table sink - EasyNetQ writes log records using tabs and carriage returns which are [prohibited by Azure table keys](https://msdn.microsoft.com/en-us/library/azure/dd179338.aspx). Currently I filter them in EasyNetQ to Serilog adapter but it would be nice to have such functionality in original sink.

best regards,
Alexander Alexeev
