### PR TITLE
Support `netstandard1.3` using WindowsAzure.Storage 7.2.0

### DIFF
--- a/src/Serilog.Sinks.AzureTableStorage/Sinks/AzureTableStorage/AzureBatchingTableStorageSink.cs
+++ b/src/Serilog.Sinks.AzureTableStorage/Sinks/AzureTableStorage/AzureBatchingTableStorageSink.cs
@@ -54,7 +54,7 @@ namespace Serilog.Sinks.AzureTableStorage
             if (string.IsNullOrEmpty(storageTableName)) storageTableName = typeof(LogEventEntity).Name;
 
             _table = tableClient.GetTableReference(storageTableName);
-            _table.CreateIfNotExistsAsync().Wait(_waitTimeoutMilliseconds);
+            _table.CreateIfNotExistsAsync().SyncContextSafeWait(_waitTimeoutMilliseconds);
         }
 
         protected override async Task EmitBatchAsync(IEnumerable<LogEvent> events)

--- a/src/Serilog.Sinks.AzureTableStorage/Sinks/AzureTableStorage/AzureBatchingTableStorageSink.cs
+++ b/src/Serilog.Sinks.AzureTableStorage/Sinks/AzureTableStorage/AzureBatchingTableStorageSink.cs
@@ -19,6 +19,7 @@ using Microsoft.WindowsAzure.Storage;
 using Microsoft.WindowsAzure.Storage.Table;
 using Serilog.Events;
 using Serilog.Sinks.PeriodicBatching;
+using System.Threading.Tasks;
 
 namespace Serilog.Sinks.AzureTableStorage
 {
@@ -56,13 +57,7 @@ namespace Serilog.Sinks.AzureTableStorage
             _table.CreateIfNotExistsAsync().Wait(_waitTimeoutMilliseconds);
         }
 
-        /// <summary>
-        /// Emit a batch of log events, running to completion synchronously.
-        /// </summary>
-        /// <param name="events">The events to emit.</param>
-        /// <remarks>Override either <see cref="PeriodicBatchingSink.EmitBatch"/> or <see cref="PeriodicBatchingSink.EmitBatchAsync"/>,
-        /// not both.</remarks>
-        protected override void EmitBatch(IEnumerable<LogEvent> events)
+        protected override async Task EmitBatchAsync(IEnumerable<LogEvent> events)
         {
             var operation = new TableBatchOperation();
             
@@ -89,8 +84,7 @@ namespace Serilog.Sinks.AzureTableStorage
                 _batchRowId++;
             }
 
-            _table.ExecuteBatchAsync(operation)
-                .Wait(_waitTimeoutMilliseconds);
+            await _table.ExecuteBatchAsync(operation);
         }
 
     }

--- a/src/Serilog.Sinks.AzureTableStorage/Sinks/AzureTableStorage/AzureTableStorageSink.cs
+++ b/src/Serilog.Sinks.AzureTableStorage/Sinks/AzureTableStorage/AzureTableStorageSink.cs
@@ -48,7 +48,7 @@ namespace Serilog.Sinks.AzureTableStorage
             }
 
             _table = tableClient.GetTableReference(storageTableName);
-            _table.CreateIfNotExistsAsync().Wait(_waitTimeoutMilliseconds);
+            _table.CreateIfNotExistsAsync().SyncContextSafeWait(_waitTimeoutMilliseconds);
         }
 
         /// <summary>
@@ -62,8 +62,9 @@ namespace Serilog.Sinks.AzureTableStorage
                 _formatProvider,
                 logEvent.Timestamp.ToUniversalTime().Ticks);
             EnsureUniqueRowKey(logEventEntity);
+
             _table.ExecuteAsync(TableOperation.Insert(logEventEntity))
-                .Wait(_waitTimeoutMilliseconds);
+                .SyncContextSafeWait(_waitTimeoutMilliseconds);
         }
 
         /// <summary>

--- a/src/Serilog.Sinks.AzureTableStorage/Sinks/AzureTableStorage/AzureTableStorageSink.cs
+++ b/src/Serilog.Sinks.AzureTableStorage/Sinks/AzureTableStorage/AzureTableStorageSink.cs
@@ -26,6 +26,7 @@ namespace Serilog.Sinks.AzureTableStorage
     /// </summary>
     public class AzureTableStorageSink : ILogEventSink
     {
+        readonly int _waitTimeoutMilliseconds = Timeout.Infinite;
         readonly IFormatProvider _formatProvider;
         readonly CloudTable _table;
         long _rowKeyIndex;
@@ -47,7 +48,7 @@ namespace Serilog.Sinks.AzureTableStorage
             }
 
             _table = tableClient.GetTableReference(storageTableName);
-            _table.CreateIfNotExists();
+            _table.CreateIfNotExistsAsync().Wait(_waitTimeoutMilliseconds);
         }
 
         /// <summary>
@@ -61,7 +62,8 @@ namespace Serilog.Sinks.AzureTableStorage
                 _formatProvider,
                 logEvent.Timestamp.ToUniversalTime().Ticks);
             EnsureUniqueRowKey(logEventEntity);
-            _table.Execute(TableOperation.Insert(logEventEntity));
+            _table.ExecuteAsync(TableOperation.Insert(logEventEntity))
+                .Wait(_waitTimeoutMilliseconds);
         }
 
         /// <summary>

--- a/src/Serilog.Sinks.AzureTableStorage/Sinks/AzureTableStorageWithProperties/AzureBatchingTableStorageWithPropertiesSink.cs
+++ b/src/Serilog.Sinks.AzureTableStorage/Sinks/AzureTableStorageWithProperties/AzureBatchingTableStorageWithPropertiesSink.cs
@@ -19,6 +19,7 @@ using Serilog.Sinks.PeriodicBatching;
 using System;
 using System.Collections.Generic;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace Serilog.Sinks.AzureTableStorage
 {
@@ -63,13 +64,7 @@ namespace Serilog.Sinks.AzureTableStorage
 			}
 		}
 
-		/// <summary>
-		/// Emit a batch of log events, running to completion synchronously.
-		/// </summary>
-		/// <param name="events">The events to emit.</param>
-		/// <remarks>Override either <see cref="PeriodicBatchingSink.EmitBatch"/> or <see cref="PeriodicBatchingSink.EmitBatchAsync"/>,
-		/// not both.</remarks>
-		protected override void EmitBatch(IEnumerable<LogEvent> events)
+		protected override async Task EmitBatchAsync(IEnumerable<LogEvent> events)
 		{
 			string lastPartitionKey = null;
 			TableBatchOperation operation = null;
@@ -94,8 +89,7 @@ namespace Serilog.Sinks.AzureTableStorage
 					// If there is an operation currently in use, execute it
 					if (operation != null)
 					{
-						_table.ExecuteBatchAsync(operation)
-                            .Wait(_waitTimeoutMilliseconds);
+						await _table.ExecuteBatchAsync(operation);
 					}
 
 					// Create a new batch operation and zero count
@@ -110,8 +104,7 @@ namespace Serilog.Sinks.AzureTableStorage
 			}
 
 			// Execute last batch
-			_table.ExecuteBatchAsync(operation)
-                .Wait(_waitTimeoutMilliseconds);
+		    await _table.ExecuteBatchAsync(operation);
 		}
 	}
 }

--- a/src/Serilog.Sinks.AzureTableStorage/Sinks/AzureTableStorageWithProperties/AzureBatchingTableStorageWithPropertiesSink.cs
+++ b/src/Serilog.Sinks.AzureTableStorage/Sinks/AzureTableStorageWithProperties/AzureBatchingTableStorageWithPropertiesSink.cs
@@ -14,14 +14,11 @@
 
 using Microsoft.WindowsAzure.Storage;
 using Microsoft.WindowsAzure.Storage.Table;
-using Serilog.Core;
 using Serilog.Events;
 using Serilog.Sinks.PeriodicBatching;
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using System.Threading;
 
 namespace Serilog.Sinks.AzureTableStorage
 {
@@ -30,6 +27,7 @@ namespace Serilog.Sinks.AzureTableStorage
 	/// </summary>
 	public class AzureBatchingTableStorageWithPropertiesSink : PeriodicBatchingSink
 	{
+	    private readonly int _waitTimeoutMilliseconds = Timeout.Infinite;
 		private readonly IFormatProvider _formatProvider;
 		private readonly CloudTable _table;
 		private readonly string _additionalRowKeyPostfix;
@@ -55,7 +53,7 @@ namespace Serilog.Sinks.AzureTableStorage
 			}
 
 			_table = tableClient.GetTableReference(storageTableName);
-			_table.CreateIfNotExists();
+			_table.CreateIfNotExistsAsync().Wait(_waitTimeoutMilliseconds);
 
 			_formatProvider = formatProvider;
 
@@ -96,7 +94,8 @@ namespace Serilog.Sinks.AzureTableStorage
 					// If there is an operation currently in use, execute it
 					if (operation != null)
 					{
-						_table.ExecuteBatch(operation);
+						_table.ExecuteBatchAsync(operation)
+                            .Wait(_waitTimeoutMilliseconds);
 					}
 
 					// Create a new batch operation and zero count
@@ -111,7 +110,8 @@ namespace Serilog.Sinks.AzureTableStorage
 			}
 
 			// Execute last batch
-			_table.ExecuteBatch(operation);
+			_table.ExecuteBatchAsync(operation)
+                .Wait(_waitTimeoutMilliseconds);
 		}
 	}
 }

--- a/src/Serilog.Sinks.AzureTableStorage/Sinks/AzureTableStorageWithProperties/AzureBatchingTableStorageWithPropertiesSink.cs
+++ b/src/Serilog.Sinks.AzureTableStorage/Sinks/AzureTableStorageWithProperties/AzureBatchingTableStorageWithPropertiesSink.cs
@@ -54,7 +54,7 @@ namespace Serilog.Sinks.AzureTableStorage
 			}
 
 			_table = tableClient.GetTableReference(storageTableName);
-			_table.CreateIfNotExistsAsync().Wait(_waitTimeoutMilliseconds);
+			_table.CreateIfNotExistsAsync().SyncContextSafeWait(_waitTimeoutMilliseconds);
 
 			_formatProvider = formatProvider;
 

--- a/src/Serilog.Sinks.AzureTableStorage/Sinks/AzureTableStorageWithProperties/AzureTableStorageWithPropertiesSink.cs
+++ b/src/Serilog.Sinks.AzureTableStorage/Sinks/AzureTableStorageWithProperties/AzureTableStorageWithPropertiesSink.cs
@@ -17,11 +17,7 @@ using Microsoft.WindowsAzure.Storage.Table;
 using Serilog.Core;
 using Serilog.Events;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading;
-using System.Threading.Tasks;
 
 namespace Serilog.Sinks.AzureTableStorage
 {
@@ -30,7 +26,8 @@ namespace Serilog.Sinks.AzureTableStorage
 	/// </summary>
 	public class AzureTableStorageWithPropertiesSink : ILogEventSink
 	{
-		private readonly IFormatProvider _formatProvider;
+	    private readonly int _waitTimeoutMilliseconds = Timeout.Infinite;
+        private readonly IFormatProvider _formatProvider;
 		private readonly CloudTable _table;
 		private readonly string _additionalRowKeyPostfix;
 
@@ -51,7 +48,7 @@ namespace Serilog.Sinks.AzureTableStorage
 			}
 
 			_table = tableClient.GetTableReference(storageTableName);
-			_table.CreateIfNotExists();
+			_table.CreateIfNotExistsAsync().Wait(_waitTimeoutMilliseconds);
 
 			_formatProvider = formatProvider;
 
@@ -67,7 +64,10 @@ namespace Serilog.Sinks.AzureTableStorage
 		/// <param name="logEvent">The log event to write.</param>
 		public void Emit(LogEvent logEvent)
 		{
-			_table.Execute(TableOperation.Insert(AzureTableStorageEntityFactory.CreateEntityWithProperties(logEvent, _formatProvider, _additionalRowKeyPostfix)));
+		    var op = TableOperation.Insert(
+		        AzureTableStorageEntityFactory.CreateEntityWithProperties(logEvent, _formatProvider, _additionalRowKeyPostfix));
+            
+            _table.ExecuteAsync(op).Wait(_waitTimeoutMilliseconds);
 		}
 	}
 }

--- a/src/Serilog.Sinks.AzureTableStorage/Sinks/AzureTableStorageWithProperties/AzureTableStorageWithPropertiesSink.cs
+++ b/src/Serilog.Sinks.AzureTableStorage/Sinks/AzureTableStorageWithProperties/AzureTableStorageWithPropertiesSink.cs
@@ -48,7 +48,7 @@ namespace Serilog.Sinks.AzureTableStorage
 			}
 
 			_table = tableClient.GetTableReference(storageTableName);
-			_table.CreateIfNotExistsAsync().Wait(_waitTimeoutMilliseconds);
+			_table.CreateIfNotExistsAsync().SyncContextSafeWait(_waitTimeoutMilliseconds);
 
 			_formatProvider = formatProvider;
 
@@ -67,7 +67,7 @@ namespace Serilog.Sinks.AzureTableStorage
 		    var op = TableOperation.Insert(
 		        AzureTableStorageEntityFactory.CreateEntityWithProperties(logEvent, _formatProvider, _additionalRowKeyPostfix));
             
-            _table.ExecuteAsync(op).Wait(_waitTimeoutMilliseconds);
+            _table.ExecuteAsync(op).SyncContextSafeWait(_waitTimeoutMilliseconds);
 		}
 	}
 }

--- a/src/Serilog.Sinks.AzureTableStorage/TaskExtensions.cs
+++ b/src/Serilog.Sinks.AzureTableStorage/TaskExtensions.cs
@@ -1,0 +1,25 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+
+namespace Serilog.Sinks.AzureTableStorage
+{
+    static class TaskExtensions
+    {
+        public static bool SyncContextSafeWait(this Task task, int timeout = Timeout.Infinite)
+        {
+            var prevContext = SynchronizationContext.Current;
+            SynchronizationContext.SetSynchronizationContext(null);
+            try
+            {
+                // Wait so that the timer thread stays busy and thus
+                // we know we're working when flushing.
+                return task.Wait(timeout);
+            }
+            finally
+            {
+                SynchronizationContext.SetSynchronizationContext(prevContext);
+            }
+        }
+
+    }
+}

--- a/src/Serilog.Sinks.AzureTableStorage/project.json
+++ b/src/Serilog.Sinks.AzureTableStorage/project.json
@@ -1,5 +1,5 @@
 ﻿{
-    "version": "2.0.1-*",
+    "version": "3.0.0-*",
     "description": "Serilog event sink that writes to Azure Table Storage over HTTP.",
     
     "authors": [ "Robert Moore" ],
@@ -11,29 +11,19 @@
     },
     "dependencies": {
         "Serilog": "2.0.0",
-        "Serilog.Sinks.PeriodicBatching": "2.0.0"
+        "Serilog.Sinks.PeriodicBatching": "2.0.0",
+        "WindowsAzure.Storage": "7.2.0"
     },
     "buildOptions": {
         "keyFile": "../../assets/Serilog.snk"
     },
     "frameworks": {
       "net4.5": {
-        "dependencies": {
-          "WindowsAzure.Storage": "4.3.0"
-        },
         "frameworkAssemblies": {
           "System.Configuration": ""
         }
       },
       "netstandard1.3": {
-        "buildOptions": {
-          "define": [
-            "WINDOWS_AZURE_STORAGE_ASYNC_ONLY_APIS"
-          ]
-        },
-        "dependencies": {
-          "WindowsAzure.Storage": "7.2.0"
-        },
         "imports": [
           "portable-net45+win8+wp8+wpa81"
         ]

--- a/src/Serilog.Sinks.AzureTableStorage/project.json
+++ b/src/Serilog.Sinks.AzureTableStorage/project.json
@@ -11,17 +11,32 @@
     },
     "dependencies": {
         "Serilog": "2.0.0",
-        "Serilog.Sinks.PeriodicBatching": "2.0.0",
-        "WindowsAzure.Storage": "4.3.0"
+        "Serilog.Sinks.PeriodicBatching": "2.0.0"
     },
     "buildOptions": {
         "keyFile": "../../assets/Serilog.snk"
     },
     "frameworks": {
-        "net4.5": {
-            "frameworkAssemblies": {
-                "System.Configuration": ""
-            }
+      "net4.5": {
+        "dependencies": {
+          "WindowsAzure.Storage": "4.3.0"
+        },
+        "frameworkAssemblies": {
+          "System.Configuration": ""
         }
+      },
+      "netstandard1.3": {
+        "buildOptions": {
+          "define": [
+            "WINDOWS_AZURE_STORAGE_ASYNC_ONLY_APIS"
+          ]
+        },
+        "dependencies": {
+          "WindowsAzure.Storage": "7.2.0"
+        },
+        "imports": [
+          "portable-net45+win8+wp8+wpa81"
+        ]
+      } 
     }
 }

--- a/test/Serilog.Sinks.AzureTableStorageWithProperties.Tests/project.json
+++ b/test/Serilog.Sinks.AzureTableStorageWithProperties.Tests/project.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "Serilog.Sinks.AzureTableStorage": { "target": "project" },
     "xunit": "2.2.0-*",
-    "dotnet-test-xunit": "2.2.0-preview2-build1029"
+    "dotnet-test-xunit": "2.2.0-*"
   },
 
   "buildOptions": {
@@ -12,9 +12,18 @@
   },
   "frameworks": {
     "net4.5.2": {
-      "buildOptions": {
-        "define": [ "APPDOMAIN", "REMOTING", "GETCURRENTMETHOD" ]
+
+    },
+    "netcoreapp1.0": {
+      "imports": [
+        "portable-net45+win8+wp8+wpa81"
+      ],
+      "dependencies": {
+        "Microsoft.NETCore.App": {
+          "type": "platform",
+          "version": "1.0.0"
+        }
       }
-    }
+    } 
   }
 }


### PR DESCRIPTION
We have to use the async APIs now, because that's all that is available in the `WindowsAzure.Storage` 7.2.0.

The easiest thing to do here is to immediately await the tasks, keeping compatibility with the synchronous nature of previous versions of the sink.

P.s. I still need to cleanup the tabbing and spacing and add an editorconfig :cry: 