### PR TITLE
Add carriage return and line feed characters to the list of disallowed row key characters.

### DIFF
--- a/src/Serilog.Sinks.AzureTableStorage/ObjectNaming.cs
+++ b/src/Serilog.Sinks.AzureTableStorage/ObjectNaming.cs
@@ -1,0 +1,28 @@
+﻿using System.Text.RegularExpressions;
+
+namespace Serilog.Sinks.AzureTableStorage
+{
+    /// <summary>
+    /// Defines naming restrictions for Azure Table Storage objects
+    /// </summary>
+    public static class ObjectNaming
+    {
+        /// <summary>
+        /// The regex defining characters which are disallowed for key field values.
+        /// </summary>
+        /// <see href="https://msdn.microsoft.com/en-us/library/azure/dd179338.aspx"/>
+        public static readonly Regex KeyFieldValueCharactersNotAllowedMatch =
+            new Regex(@"(\\|/|#|\?|[\x00-\x1f]|[\x7f-\x9f])");
+
+        /// <summary>
+        /// Given a <param name="keyValue">key value</param>, returns a value
+        /// which has been 'cleaned' of any disallowed characters and trimmed
+        /// to the allowed length.
+        /// </summary>
+        public static string GetValidKeyValue(string keyValue)
+        {
+            keyValue = KeyFieldValueCharactersNotAllowedMatch.Replace(keyValue, "");
+            return keyValue.Length > 1024 ? keyValue.Substring(0, 1024) : keyValue;
+        }
+    }
+}

--- a/src/Serilog.Sinks.AzureTableStorage/Sinks/AzureTableStorage/LogEventEntity.cs
+++ b/src/Serilog.Sinks.AzureTableStorage/Sinks/AzureTableStorage/LogEventEntity.cs
@@ -32,8 +32,6 @@ namespace Serilog.Sinks.AzureTableStorage
     /// </remarks>
     public class LogEventEntity : TableEntity
     {
-        static readonly Regex RowKeyNotAllowedMatch = new Regex(@"(\\|/|#|\?|[\x00-\x1f]|[\x7f-\x9f])");
-
         /// <summary>
         /// Default constructor for the Storage Client library to re-hydrate entities when querying.
         /// </summary>
@@ -62,7 +60,7 @@ namespace Serilog.Sinks.AzureTableStorage
         // http://msdn.microsoft.com/en-us/library/windowsazure/dd179338.aspx
         static string GetValidRowKey(string rowKey)
         {
-            rowKey = RowKeyNotAllowedMatch.Replace(rowKey, "");
+            rowKey = ObjectNaming.KeyFieldValueCharactersNotAllowedMatch.Replace(rowKey, "");
             return rowKey.Length > 1024 ? rowKey.Substring(0, 1024) : rowKey;
         }
 

--- a/src/Serilog.Sinks.AzureTableStorage/Sinks/AzureTableStorageWithProperties/AzureTableStorageEntityFactory.cs
+++ b/src/Serilog.Sinks.AzureTableStorage/Sinks/AzureTableStorageWithProperties/AzureTableStorageEntityFactory.cs
@@ -28,7 +28,7 @@ namespace Serilog.Sinks.AzureTableStorage
 	public static class AzureTableStorageEntityFactory
 	{
 		// Valid RowKey name characters
-		static readonly Regex _rowKeyNotAllowedMatch = new Regex(@"(\\|/|#|\?)");
+		static readonly Regex _rowKeyNotAllowedMatch = new Regex(@"(\\|/|#|\n|\r|\?)");
 
 		// Azure tables support a maximum of 255 properties. PartitionKey, RowKey and Timestamp
 		// bring the maximum to 252.

--- a/src/Serilog.Sinks.AzureTableStorage/Sinks/AzureTableStorageWithProperties/AzureTableStorageEntityFactory.cs
+++ b/src/Serilog.Sinks.AzureTableStorage/Sinks/AzureTableStorageWithProperties/AzureTableStorageEntityFactory.cs
@@ -27,9 +27,6 @@ namespace Serilog.Sinks.AzureTableStorage
 	/// </summary>
 	public static class AzureTableStorageEntityFactory
 	{
-		// Valid RowKey name characters
-		static readonly Regex _rowKeyNotAllowedMatch = new Regex(@"(\\|/|#|\n|\r|\?)");
-
 		// Azure tables support a maximum of 255 properties. PartitionKey, RowKey and Timestamp
 		// bring the maximum to 252.
 		const int _maxNumberOfPropertiesPerRow = 252;
@@ -99,7 +96,7 @@ namespace Serilog.Sinks.AzureTableStorage
 		/// </returns>
 		public static string GetValidStringForTableKey(string s)
 		{
-			return _rowKeyNotAllowedMatch.Replace(s, "");
+            return ObjectNaming.KeyFieldValueCharactersNotAllowedMatch.Replace(s, "");
 		}
 
 		// Generate a valid partition key from event timestamp.
@@ -133,7 +130,7 @@ namespace Serilog.Sinks.AzureTableStorage
 				postfixBuilder.Append('|').Append(additionalRowKeyPostfix);
 			}
 
-			// Append GUID to postfix	
+			// Append GUID to postfix
 			postfixBuilder.Append('|').Append(Guid.NewGuid());
 
 			// Truncate prefix if too long

--- a/test/Serilog.Sinks.AzureTableStorageWithProperties.Tests/AzureTableStorageWithPropertiesSinkTests.cs
+++ b/test/Serilog.Sinks.AzureTableStorageWithProperties.Tests/AzureTableStorageWithPropertiesSinkTests.cs
@@ -75,6 +75,31 @@ namespace Serilog.Sinks.AzureTableStorage.Tests
 		}
 
         [Fact]
+        public void WhenALoggerWritesToTheSinkWithANewlineInTheTemplateItIsRetrievable()
+        {
+            // Prompted from https://github.com/serilog/serilog-sinks-azuretablestorage/issues/10
+            var storageAccount = CloudStorageAccount.DevelopmentStorageAccount;
+            var tableClient = storageAccount.CreateCloudTableClient();
+            var table = tableClient.GetTableReference("LogEventEntity");
+
+            table.DeleteIfExists();
+
+            var logger = new LoggerConfiguration()
+                .WriteTo.AzureTableStorageWithProperties(storageAccount)
+                .CreateLogger();
+
+            var exception = new ArgumentException("Some exception");
+
+            const string messageTemplate = "Line 1\nLine2";
+
+            logger.Information(exception, messageTemplate);
+
+            var result = table.ExecuteQuery(new TableQuery().Take(1)).FirstOrDefault();
+
+            Assert.NotNull(result);
+        }
+
+        [Fact]
         public void WhenALoggerWritesToTheSinkItStoresTheCorrectTypesForScalar()
 		{
 			var storageAccount = CloudStorageAccount.DevelopmentStorageAccount;

--- a/test/Serilog.Sinks.AzureTableStorageWithProperties.Tests/AzureTableStorageWithPropertiesSinkTests.cs
+++ b/test/Serilog.Sinks.AzureTableStorageWithProperties.Tests/AzureTableStorageWithPropertiesSinkTests.cs
@@ -61,7 +61,7 @@ namespace Serilog.Sinks.AzureTableStorage.Tests
 			logger.Information(exception, messageTemplate, "Properties", 1234, ' ');
 
 			var result = table.ExecuteQuery(new TableQuery().Take(1)).First();
-			
+
 			// Check the presence of same properties as in previous version
 			Assert.Equal(messageTemplate, result.Properties["MessageTemplate"].StringValue);
 			Assert.Equal("Information", result.Properties["Level"].StringValue);
@@ -88,11 +88,9 @@ namespace Serilog.Sinks.AzureTableStorage.Tests
                 .WriteTo.AzureTableStorageWithProperties(storageAccount)
                 .CreateLogger();
 
-            var exception = new ArgumentException("Some exception");
-
             const string messageTemplate = "Line 1\nLine2";
 
-            logger.Information(exception, messageTemplate);
+            logger.Information(messageTemplate);
 
             var result = table.ExecuteQuery(new TableQuery().Take(1)).FirstOrDefault();
 

--- a/test/Serilog.Sinks.AzureTableStorageWithProperties.Tests/AzureTableStorageWithPropertiesSinkTests.cs
+++ b/test/Serilog.Sinks.AzureTableStorageWithProperties.Tests/AzureTableStorageWithPropertiesSinkTests.cs
@@ -75,7 +75,30 @@ namespace Serilog.Sinks.AzureTableStorage.Tests
 		}
 
         [Fact]
-        public void WhenALoggerWritesToTheSinkWithANewlineInTheTemplateItIsRetrievable()
+        public void WhenALoggerWritesToTheSinkWithAWindowsNewlineInTheTemplateItIsRetrievable()
+        {
+            // Prompted from https://github.com/serilog/serilog-sinks-azuretablestorage/issues/10
+            var storageAccount = CloudStorageAccount.DevelopmentStorageAccount;
+            var tableClient = storageAccount.CreateCloudTableClient();
+            var table = tableClient.GetTableReference("LogEventEntity");
+
+            table.DeleteIfExists();
+
+            var logger = new LoggerConfiguration()
+                .WriteTo.AzureTableStorageWithProperties(storageAccount)
+                .CreateLogger();
+
+            const string messageTemplate = "Line 1\r\nLine2";
+
+            logger.Information(messageTemplate);
+
+            var result = table.ExecuteQuery(new TableQuery().Take(1)).FirstOrDefault();
+
+            Assert.NotNull(result);
+        }
+
+        [Fact]
+        public void WhenALoggerWritesToTheSinkWithALineFeedInTheTemplateItIsRetrievable()
         {
             // Prompted from https://github.com/serilog/serilog-sinks-azuretablestorage/issues/10
             var storageAccount = CloudStorageAccount.DevelopmentStorageAccount;
@@ -89,6 +112,29 @@ namespace Serilog.Sinks.AzureTableStorage.Tests
                 .CreateLogger();
 
             const string messageTemplate = "Line 1\nLine2";
+
+            logger.Information(messageTemplate);
+
+            var result = table.ExecuteQuery(new TableQuery().Take(1)).FirstOrDefault();
+
+            Assert.NotNull(result);
+        }
+
+        [Fact]
+        public void WhenALoggerWritesToTheSinkWithACarriageReturnInTheTemplateItIsRetrievable()
+        {
+            // Prompted from https://github.com/serilog/serilog-sinks-azuretablestorage/issues/10
+            var storageAccount = CloudStorageAccount.DevelopmentStorageAccount;
+            var tableClient = storageAccount.CreateCloudTableClient();
+            var table = tableClient.GetTableReference("LogEventEntity");
+
+            table.DeleteIfExists();
+
+            var logger = new LoggerConfiguration()
+                .WriteTo.AzureTableStorageWithProperties(storageAccount)
+                .CreateLogger();
+
+            const string messageTemplate = "Line 1\rLine2";
 
             logger.Information(messageTemplate);
 


### PR DESCRIPTION
This should address the problem reported in issue #10.  Added tests to cover each case ("\n", "\r", "\r\n").
Let me know if I missed anything.
