### PR TITLE
Delay for 500ms while the storage emulator starts up,

### DIFF
--- a/test/Serilog.Sinks.AzureTableStorageWithProperties.Tests/AzureTableStorageWithPropertiesSinkTests.cs
+++ b/test/Serilog.Sinks.AzureTableStorageWithProperties.Tests/AzureTableStorageWithPropertiesSinkTests.cs
@@ -10,36 +10,9 @@ using System.Threading.Tasks;
 
 namespace Serilog.Sinks.AzureTableStorage.Tests
 {
-    public class AzureTableStorageWithPropertiesSinkTests : IDisposable
+    [Collection("AzureStorageIntegrationTests")]
+    public class AzureTableStorageWithPropertiesSinkTests
     {
-        private readonly bool _wasStorageEmulatorUp;
-
-        public AzureTableStorageWithPropertiesSinkTests()
-        {
-            if (!AzureStorageEmulatorManager.IsProcessStarted())
-            {
-                AzureStorageEmulatorManager.StartStorageEmulator();
-                _wasStorageEmulatorUp = false;
-            }
-            else
-            {
-                _wasStorageEmulatorUp = true;
-            }
-
-        }
-
-        public void Dispose()
-        {
-            if (!_wasStorageEmulatorUp)
-            {
-                AzureStorageEmulatorManager.StopStorageEmulator();
-            }
-            else
-            {
-                // Leave as it was before testing...
-            }
-        }
-
         static async Task<IList<DynamicTableEntity>> TableQueryTakeDynamicAsync(CloudTable table, int takeCount)
         {
             var queryToken = new TableContinuationToken();

--- a/test/Serilog.Sinks.AzureTableStorageWithProperties.Tests/Infrastructure/AzureStorageEmulatorCollection.cs
+++ b/test/Serilog.Sinks.AzureTableStorageWithProperties.Tests/Infrastructure/AzureStorageEmulatorCollection.cs
@@ -1,0 +1,9 @@
+﻿using Xunit;
+
+namespace Serilog.Sinks.AzureTableStorage.Tests.Infrastructure
+{
+    [CollectionDefinition("AzureStorageIntegrationTests")]
+    public class AzureStorageEmulatorCollection : ICollectionFixture<AzureStorageEmulatorFixture>
+    {
+    }
+}

--- a/test/Serilog.Sinks.AzureTableStorageWithProperties.Tests/Infrastructure/AzureStorageEmulatorFixture.cs
+++ b/test/Serilog.Sinks.AzureTableStorageWithProperties.Tests/Infrastructure/AzureStorageEmulatorFixture.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace Serilog.Sinks.AzureTableStorage.Tests.Infrastructure
+{
+    /// <summary>
+    /// Adapted from https://github.com/kendaleiv/azure-storage-integration-tests
+    /// </summary>
+    public class AzureStorageEmulatorFixture : IDisposable
+    {
+        private readonly bool _wasStorageEmulatorUp;
+
+        public AzureStorageEmulatorFixture()
+        {
+            if (!AzureStorageEmulatorManager.IsProcessStarted())
+            {
+                AzureStorageEmulatorManager.StartStorageEmulator();
+
+                Console.WriteLine("delaying 500ms in the hopes that the storage emulator is started...");
+                Task.Delay(500).Wait(500);
+
+                _wasStorageEmulatorUp = false;
+            }
+            else
+            {
+                _wasStorageEmulatorUp = true;
+            }
+        }
+
+        public void Dispose()
+        {
+            if (!_wasStorageEmulatorUp)
+            {
+                AzureStorageEmulatorManager.StopStorageEmulator();
+            }
+            else
+            {
+                // Leave as it was before testing...
+            }
+        }
+    }
+}

--- a/test/Serilog.Sinks.AzureTableStorageWithProperties.Tests/Infrastructure/AzureStorageEmulatorManager.cs
+++ b/test/Serilog.Sinks.AzureTableStorageWithProperties.Tests/Infrastructure/AzureStorageEmulatorManager.cs
@@ -1,16 +1,16 @@
 ﻿using System.Diagnostics;
 using System.Linq;
 
-namespace Serilog.Sinks.AzureTableStorage.Tests
+namespace Serilog.Sinks.AzureTableStorage.Tests.Infrastructure
 {
-    // Start/stop azure storage emulator from code.
-    // http://stackoverflow.com/questions/7547567/how-to-start-azure-storage-emulator-from-within-a-program
-    public static class AzureStorageEmulatorManager
-    {
-        private const string _windowsAzureStorageEmulatorPath = @"C:\Program Files (x86)\Microsoft SDKs\Azure\Storage Emulator\WAStorageEmulator.exe";
-
+	// Start/stop azure storage emulator from code.
+	// http://stackoverflow.com/questions/7547567/how-to-start-azure-storage-emulator-from-within-a-program
+	public static class AzureStorageEmulatorManager
+	{
+		private const string _windowsAzureStorageEmulatorPath = @"C:\Program Files (x86)\Microsoft SDKs\Azure\Storage Emulator\WAStorageEmulator.exe";
+        
         private const string _win7ProcessName = "WAStorageEmulator";
-        private const string _win8ProcessName = "WASTOR~1";
+		private const string _win8ProcessName = "WASTOR~1";
 
         private const string _azureStorageEmulator4_4Path = @"C:\Program Files (x86)\Microsoft SDKs\Azure\Storage Emulator\AzureStorageEmulator.exe";
         private const string _processName4_4 = "AzureStorageEmulator";
@@ -28,10 +28,10 @@ namespace Serilog.Sinks.AzureTableStorage.Tests
         };
 
         private static readonly ProcessStartInfo stopStorageEmulator = new ProcessStartInfo
-        {
-            FileName = _windowsAzureStorageEmulatorPath,
-            Arguments = "stop",
-        };
+		{
+			FileName = _windowsAzureStorageEmulatorPath,
+			Arguments = "stop",
+		};
 
         private static readonly ProcessStartInfo stopStorageEmulator4_4 = new ProcessStartInfo
         {
@@ -40,19 +40,19 @@ namespace Serilog.Sinks.AzureTableStorage.Tests
         };
 
         private static Process GetProcess()
-        {
-            return Process.GetProcessesByName(_win7ProcessName).FirstOrDefault()
+		{
+			return Process.GetProcessesByName(_win7ProcessName).FirstOrDefault()
                 ?? Process.GetProcessesByName(_win8ProcessName).FirstOrDefault()
                 ?? Process.GetProcessesByName(_processName4_4).FirstOrDefault();
-        }
+		}
 
-        public static bool IsProcessStarted()
-        {
-            return GetProcess() != null;
-        }
+		public static bool IsProcessStarted()
+		{
+			return GetProcess() != null;
+		}
 
-        public static void StartStorageEmulator()
-        {
+		public static void StartStorageEmulator()
+		{
             if (!IsProcessStarted())
             {
                 try
@@ -62,7 +62,7 @@ namespace Serilog.Sinks.AzureTableStorage.Tests
                         process.WaitForExit();
                     }
                 }
-                catch(System.ComponentModel.Win32Exception ex)
+                catch (System.ComponentModel.Win32Exception ex)
                 {
                     if (ex.Message == "The system cannot find the file specified")
                     {
@@ -77,10 +77,10 @@ namespace Serilog.Sinks.AzureTableStorage.Tests
                     }
                 }
             }
-        }
+            }
 
-        public static void StopStorageEmulator()
-        {
+            public static void StopStorageEmulator()
+            {
             try
             {
                 using (Process process = Process.Start(stopStorageEmulator4_4))


### PR DESCRIPTION
and switch to using `AzureStorageIntegrationTests` collection so that we only have to wait for it to start up once.

Will this help the AppVeyor build being flakey?