### PR TITLE
added key generator support with properties sinks and extensions

### DIFF
--- a/src/Serilog.Sinks.AzureTableStorage/LoggerConfigurationAzureTableStorageExtensions.cs
+++ b/src/Serilog.Sinks.AzureTableStorage/LoggerConfigurationAzureTableStorageExtensions.cs
@@ -69,7 +69,7 @@ namespace Serilog
 
             var sink = writeInBatches ?
                 (ILogEventSink)new AzureBatchingTableStorageSink(storageAccount, formatProvider,  batchPostingLimit ?? DefaultBatchPostingLimit, period ?? DefaultPeriod, storageTableName, keyGenerator) :
-                new AzureTableStorageSink(storageAccount, formatProvider, storageTableName);
+                new AzureTableStorageSink(storageAccount, formatProvider, storageTableName, keyGenerator);
 
             return loggerConfiguration.Sink(sink, restrictedToMinimumLevel);
         }

--- a/src/Serilog.Sinks.AzureTableStorage/LoggerConfigurationAzureTableStorageWithPropertiesExtensions.cs
+++ b/src/Serilog.Sinks.AzureTableStorage/LoggerConfigurationAzureTableStorageWithPropertiesExtensions.cs
@@ -18,6 +18,8 @@ using Serilog.Core;
 using Serilog.Events;
 using Serilog.Sinks.AzureTableStorage;
 using System;
+using Serilog.Sinks.AzureTableStorage.KeyGenerator;
+using Serilog.Sinks.AzureTableStorage.Sinks.KeyGenerator;
 
 namespace Serilog
 {
@@ -50,6 +52,7 @@ namespace Serilog
         /// <param name="batchPostingLimit">The maximum number of events to post in a single batch.</param>
         /// <param name="period">The time to wait between checking for event batches.</param>
         /// <param name="additionalRowKeyPostfix">Additional postfix string that will be appended to row keys</param>
+        /// <param name="keyGenerator">Generates the PartitionKey and the RowKey</param>
         /// <returns>Logger configuration, allowing configuration to continue.</returns>
         /// <exception cref="ArgumentNullException">A required parameter is null.</exception>
         public static LoggerConfiguration AzureTableStorageWithProperties(
@@ -61,14 +64,16 @@ namespace Serilog
             bool writeInBatches = false,
             TimeSpan? period = null,
             int? batchPostingLimit = null,
-            string additionalRowKeyPostfix = null)
+            string additionalRowKeyPostfix = null,
+            IKeyGenerator keyGenerator = null)
         {
             if (loggerConfiguration == null) throw new ArgumentNullException("loggerConfiguration");
             if (storageAccount == null) throw new ArgumentNullException("storageAccount");
 
-            var sink = writeInBatches ?
-                (ILogEventSink)new AzureBatchingTableStorageWithPropertiesSink(storageAccount, formatProvider, batchPostingLimit ?? DefaultBatchPostingLimit, period ?? DefaultPeriod, storageTableName, additionalRowKeyPostfix) :
-                new AzureTableStorageWithPropertiesSink(storageAccount, formatProvider, storageTableName, additionalRowKeyPostfix);
+            var sink = writeInBatches
+                ? (ILogEventSink)
+                new AzureBatchingTableStorageWithPropertiesSink(storageAccount, formatProvider, batchPostingLimit ?? DefaultBatchPostingLimit, period ?? DefaultPeriod, storageTableName, additionalRowKeyPostfix, keyGenerator)
+                : new AzureTableStorageWithPropertiesSink(storageAccount, formatProvider, storageTableName, additionalRowKeyPostfix, keyGenerator);
 
             return loggerConfiguration.Sink(sink, restrictedToMinimumLevel);
         }
@@ -86,6 +91,7 @@ namespace Serilog
         /// <param name="batchPostingLimit">The maximum number of events to post in a single batch.</param>
         /// <param name="period">The time to wait between checking for event batches.</param>
         /// <param name="additionalRowKeyPostfix">Additional postfix string that will be appended to row keys</param>
+        /// <param name="keyGenerator">Generates the PartitionKey and the RowKey</param>
         /// <returns>Logger configuration, allowing configuration to continue.</returns>
         /// <exception cref="ArgumentNullException">A required parameter is null.</exception>
         public static LoggerConfiguration AzureTableStorageWithProperties(
@@ -97,12 +103,13 @@ namespace Serilog
             bool writeInBatches = false,
             TimeSpan? period = null,
             int? batchPostingLimit = null,
-            string additionalRowKeyPostfix = null)
+            string additionalRowKeyPostfix = null,
+            IKeyGenerator keyGenerator = null)
         {
             if (loggerConfiguration == null) throw new ArgumentNullException("loggerConfiguration");
             if (String.IsNullOrEmpty(connectionString)) throw new ArgumentNullException("connectionString");
             var storageAccount = CloudStorageAccount.Parse(connectionString);
-            return AzureTableStorageWithProperties(loggerConfiguration, storageAccount, restrictedToMinimumLevel, formatProvider, storageTableName, writeInBatches, period, batchPostingLimit, additionalRowKeyPostfix);
+            return AzureTableStorageWithProperties(loggerConfiguration, storageAccount, restrictedToMinimumLevel, formatProvider, storageTableName, writeInBatches, period, batchPostingLimit, additionalRowKeyPostfix, keyGenerator);
         }
     }
 }

--- a/src/Serilog.Sinks.AzureTableStorage/Serilog.Sinks.AzureTableStorage.nuspec
+++ b/src/Serilog.Sinks.AzureTableStorage/Serilog.Sinks.AzureTableStorage.nuspec
@@ -11,8 +11,9 @@
     <iconUrl>http://serilog.net/images/serilog-sink-nuget.png</iconUrl>
     <tags>serilog logging azure</tags>
     <dependencies>
-      <dependency id="Serilog" version="2.0" />
-      <dependency id="WindowsAzure.Storage" version="2.0" />
+      <dependency id="Serilog" version="2.3.0" />
+      <dependency id="Serilog.Sinks.PeriodicBatching" version="2.1.0" />
+      <dependency id="WindowsAzure.Storage" version="7.2.0" />
     </dependencies>
   </metadata>
 </package>

--- a/src/Serilog.Sinks.AzureTableStorage/Sinks/AzureTableStorage/AzureTableStorageSink.cs
+++ b/src/Serilog.Sinks.AzureTableStorage/Sinks/AzureTableStorage/AzureTableStorageSink.cs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 using System;
-using System.Globalization;
 using System.Threading;
 using Microsoft.WindowsAzure.Storage;
 using Microsoft.WindowsAzure.Storage.Table;
@@ -32,20 +31,6 @@ namespace Serilog.Sinks.AzureTableStorage
         readonly IFormatProvider _formatProvider;
         readonly IKeyGenerator _keyGenerator;
         readonly CloudTable _table;
-
-        /// <summary>
-        /// Construct a sink that saves logs to the specified storage account.
-        /// </summary>
-        /// <param name="storageAccount">The Cloud Storage Account to use to insert the log entries to.</param>
-        /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
-        /// <param name="storageTableName">Table name that log entries will be written to. Note: Optional, setting this may impact performance</param>
-        public AzureTableStorageSink(
-            CloudStorageAccount storageAccount,
-            IFormatProvider formatProvider,
-            string storageTableName
-            ) :this(storageAccount, formatProvider, storageTableName, new DefaultKeyGenerator())
-        {
-        }
 
         /// <summary>
         /// Construct a sink that saves logs to the specified storage account.

--- a/src/Serilog.Sinks.AzureTableStorage/Sinks/AzureTableStorageWithProperties/AzureTableStorageEntityFactory.cs
+++ b/src/Serilog.Sinks.AzureTableStorage/Sinks/AzureTableStorageWithProperties/AzureTableStorageEntityFactory.cs
@@ -16,9 +16,8 @@ using Microsoft.WindowsAzure.Storage.Table;
 using Serilog.Events;
 using System;
 using System.Collections.Generic;
-using System.IO;
-using System.Text;
 using System.Text.RegularExpressions;
+using Serilog.Sinks.AzureTableStorage.KeyGenerator;
 
 namespace Serilog.Sinks.AzureTableStorage
 {
@@ -27,9 +26,6 @@ namespace Serilog.Sinks.AzureTableStorage
     /// </summary>
     public static class AzureTableStorageEntityFactory
     {
-        // Valid RowKey name characters
-        static readonly Regex _rowKeyNotAllowedMatch = new Regex(@"(\\|/|#|\?|\r\n?|\n)");
-
         // Azure tables support a maximum of 255 properties. PartitionKey, RowKey and Timestamp
         // bring the maximum to 252.
         const int _maxNumberOfPropertiesPerRow = 252;
@@ -41,14 +37,16 @@ namespace Serilog.Sinks.AzureTableStorage
         /// <param name="logEvent">The event to log</param>
         /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
         /// <param name="additionalRowKeyPostfix">Additional postfix string that will be appended to row keys</param>
+        /// <param name="keyGenerator">The IKeyGenerator for the PartitionKey and RowKey</param>
         /// <returns></returns>
-        public static DynamicTableEntity CreateEntityWithProperties(LogEvent logEvent, IFormatProvider formatProvider, string additionalRowKeyPostfix)
+        public static DynamicTableEntity CreateEntityWithProperties(LogEvent logEvent, IFormatProvider formatProvider, string additionalRowKeyPostfix, IKeyGenerator keyGenerator)
         {
-            var tableEntity = new DynamicTableEntity();
-
-            tableEntity.PartitionKey = GenerateValidPartitionKey(logEvent);
-            tableEntity.RowKey = GenerateValidRowKey(logEvent, additionalRowKeyPostfix);
-            tableEntity.Timestamp = logEvent.Timestamp;
+            var tableEntity = new DynamicTableEntity
+            {
+                PartitionKey = keyGenerator.GeneratePartitionKey(logEvent),
+                RowKey = keyGenerator.GenerateRowKey(logEvent, additionalRowKeyPostfix),
+                Timestamp = logEvent.Timestamp
+            };
 
             var dynamicProperties = tableEntity.Properties;
 
@@ -61,9 +59,8 @@ namespace Serilog.Sinks.AzureTableStorage
                 dynamicProperties.Add("Exception", new EntityProperty(logEvent.Exception.ToString()));
             }
 
-
             List<KeyValuePair<ScalarValue, LogEventPropertyValue>> additionalData = null;
-            int count = dynamicProperties.Count;
+            var count = dynamicProperties.Count;
             foreach (var logProperty in logEvent.Properties)
             {
                 if (count++ < _maxNumberOfPropertiesPerRow - 1)
@@ -86,64 +83,6 @@ namespace Serilog.Sinks.AzureTableStorage
             }
 
             return tableEntity;
-        }
-
-        /// <summary>
-        /// Generate a valid string for a table property key by removing invalid characters
-        /// </summary>
-        /// <param name="s">
-        /// The input string
-        /// </param>
-        /// <returns>
-        /// The string that can be used as a property
-        /// </returns>
-        public static string GetValidStringForTableKey(string s)
-        {
-            return _rowKeyNotAllowedMatch.Replace(s, "");
-        }
-
-        // Generate a valid partition key from event timestamp.
-        private static string GenerateValidPartitionKey(LogEvent logEvent)
-        {
-            // Like WAD, round the timestamp the minute.
-            return "0" + new DateTime(
-                logEvent.Timestamp.Year,
-                logEvent.Timestamp.Month,
-                logEvent.Timestamp.Day,
-                logEvent.Timestamp.Hour,
-                logEvent.Timestamp.Minute,
-                0).Ticks;
-        }
-
-        // Generate a valid Row Key by joining postfix and prefix. If longer
-        // than 1K, prefix is truncated.
-        // See http://msdn.microsoft.com/en-us/library/windowsazure/dd179338.aspx
-        private static string GenerateValidRowKey(LogEvent logEvent, string additionalRowKeyPostfix)
-        {
-            var prefixBuilder = new StringBuilder(512);
-
-            // Join level and message template
-            prefixBuilder.Append(logEvent.Level).Append('|').Append(GetValidStringForTableKey(logEvent.MessageTemplate.Text));
-
-            var postfixBuilder = new StringBuilder(512);
-
-            if (additionalRowKeyPostfix != null)
-            {
-                // additionalRowKeyPostfix is already stripped of invalid characters
-                postfixBuilder.Append('|').Append(additionalRowKeyPostfix);
-            }
-
-            // Append GUID to postfix
-            postfixBuilder.Append('|').Append(Guid.NewGuid());
-
-            // Truncate prefix if too long
-            var maxPrefixLength = 1024 - postfixBuilder.Length;
-            if (prefixBuilder.Length > maxPrefixLength)
-            {
-                prefixBuilder.Length = maxPrefixLength;
-            }
-
-            return prefixBuilder.Append(postfixBuilder).ToString();
         }
     }
 }

--- a/src/Serilog.Sinks.AzureTableStorage/Sinks/AzureTableStorageWithProperties/AzureTableStorageWithPropertiesSink.cs
+++ b/src/Serilog.Sinks.AzureTableStorage/Sinks/AzureTableStorageWithProperties/AzureTableStorageWithPropertiesSink.cs
@@ -18,6 +18,8 @@ using Serilog.Core;
 using Serilog.Events;
 using System;
 using System.Threading;
+using Serilog.Sinks.AzureTableStorage.KeyGenerator;
+using Serilog.Sinks.AzureTableStorage.Sinks.KeyGenerator;
 
 namespace Serilog.Sinks.AzureTableStorage
 {
@@ -30,6 +32,7 @@ namespace Serilog.Sinks.AzureTableStorage
         private readonly IFormatProvider _formatProvider;
         private readonly CloudTable _table;
         private readonly string _additionalRowKeyPostfix;
+        private readonly IKeyGenerator _keyGenerator;
 
         /// <summary>
         /// Construct a sink that saves logs to the specified storage account.
@@ -38,7 +41,8 @@ namespace Serilog.Sinks.AzureTableStorage
         /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
         /// <param name="storageTableName">Table name that log entries will be written to. Note: Optional, setting this may impact performance</param>
         /// <param name="additionalRowKeyPostfix">Additional postfix string that will be appended to row keys</param>
-        public AzureTableStorageWithPropertiesSink(CloudStorageAccount storageAccount, IFormatProvider formatProvider, string storageTableName = null, string additionalRowKeyPostfix = null)
+        /// <param name="keyGenerator">Generates the PartitionKey and the RowKey</param>
+        public AzureTableStorageWithPropertiesSink(CloudStorageAccount storageAccount, IFormatProvider formatProvider, string storageTableName = null, string additionalRowKeyPostfix = null, IKeyGenerator keyGenerator = null)
         {
             var tableClient = storageAccount.CreateCloudTableClient();
 
@@ -51,11 +55,8 @@ namespace Serilog.Sinks.AzureTableStorage
             _table.CreateIfNotExistsAsync().SyncContextSafeWait(_waitTimeoutMilliseconds);
 
             _formatProvider = formatProvider;
-
-            if (additionalRowKeyPostfix != null)
-            {
-                _additionalRowKeyPostfix = AzureTableStorageEntityFactory.GetValidStringForTableKey(additionalRowKeyPostfix);
-            }
+            _additionalRowKeyPostfix = additionalRowKeyPostfix;
+            _keyGenerator = keyGenerator ?? new PropertiesKeyGenerator();
         }
 
         /// <summary>
@@ -64,8 +65,7 @@ namespace Serilog.Sinks.AzureTableStorage
         /// <param name="logEvent">The log event to write.</param>
         public void Emit(LogEvent logEvent)
         {
-            var op = TableOperation.Insert(
-                AzureTableStorageEntityFactory.CreateEntityWithProperties(logEvent, _formatProvider, _additionalRowKeyPostfix));
+            var op = TableOperation.Insert(AzureTableStorageEntityFactory.CreateEntityWithProperties(logEvent, _formatProvider, _additionalRowKeyPostfix, _keyGenerator));
 
             _table.ExecuteAsync(op).SyncContextSafeWait(_waitTimeoutMilliseconds);
         }

--- a/src/Serilog.Sinks.AzureTableStorage/Sinks/KeyGenerator/DefaultKeyGenerator.cs
+++ b/src/Serilog.Sinks.AzureTableStorage/Sinks/KeyGenerator/DefaultKeyGenerator.cs
@@ -3,7 +3,7 @@ using Serilog.Events;
 
 namespace Serilog.Sinks.AzureTableStorage.KeyGenerator
 {
-    class DefaultKeyGenerator : IKeyGenerator
+    public class DefaultKeyGenerator : IKeyGenerator
     {
         protected long RowId;
 
@@ -12,14 +12,25 @@ namespace Serilog.Sinks.AzureTableStorage.KeyGenerator
             RowId = 0L;
         }
 
-        public string GeneratePartitionKey(LogEvent logEvent)
+        /// <summary>
+        /// Automatically generates the PartitionKey based on the logEvent timestamp
+        /// </summary>
+        /// <param name="logEvent">the log event</param>
+        /// <returns>The Generated PartitionKey</returns>
+        public virtual string GeneratePartitionKey(LogEvent logEvent)
         {
             var utcEventTime = logEvent.Timestamp.UtcDateTime;
             var timeWithoutMilliseconds = utcEventTime.AddMilliseconds(-utcEventTime.Millisecond);
             return $"0{timeWithoutMilliseconds.Ticks}";
         }
 
-        public string GenerateRowKey(LogEvent logEvent)
+        /// <summary>
+        /// Automatically generates the RowKey using the following template: {Level|MessageTemplate|IncrementedRowId}
+        /// </summary>
+        /// <param name="logEvent">the log event</param>
+        /// <param name="suffix">Suffix to add to RowKey</param>
+        /// <returns>The generated RowKey</returns>
+        public virtual string GenerateRowKey(LogEvent logEvent, string suffix = null)
         {
             return $"{logEvent.Level}|{logEvent.MessageTemplate}|{Interlocked.Increment(ref RowId)}";
         }

--- a/src/Serilog.Sinks.AzureTableStorage/Sinks/KeyGenerator/IKeyGenerator.cs
+++ b/src/Serilog.Sinks.AzureTableStorage/Sinks/KeyGenerator/IKeyGenerator.cs
@@ -18,7 +18,8 @@ namespace Serilog.Sinks.AzureTableStorage.KeyGenerator
         /// Generate a row key for the supplied <paramref name="logEvent"/>.
         /// </summary>
         /// <param name="logEvent">the log event</param>
+        /// <param name="suffix">suffix to the RowKey</param>
         /// <returns>the row key that should be stored in the Azure table</returns>
-        string GenerateRowKey(LogEvent logEvent);
+        string GenerateRowKey(LogEvent logEvent, string suffix = null);
     }
 }

--- a/src/Serilog.Sinks.AzureTableStorage/Sinks/KeyGenerator/PropertiesKeyGenerator.cs
+++ b/src/Serilog.Sinks.AzureTableStorage/Sinks/KeyGenerator/PropertiesKeyGenerator.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Text;
+using System.Text.RegularExpressions;
+using Serilog.Events;
+using Serilog.Sinks.AzureTableStorage.KeyGenerator;
+
+namespace Serilog.Sinks.AzureTableStorage.Sinks.KeyGenerator
+{
+    public class PropertiesKeyGenerator : DefaultKeyGenerator
+    {
+        // Valid RowKey name characters
+        static readonly Regex _rowKeyNotAllowedMatch = new Regex(@"(\\|/|#|\?|\r\n?|\n)");
+
+        /// <summary>
+        /// Generate a valid string for a table property key by removing invalid characters
+        /// </summary>
+        /// <param name="s">
+        /// The input string
+        /// </param>
+        /// <returns>
+        /// The string that can be used as a property
+        /// </returns>
+        public static string GetValidStringForTableKey(string s)
+        {
+            return _rowKeyNotAllowedMatch.Replace(s, "");
+        }
+
+        /// <summary>
+        /// Automatically generates the RowKey using the following template: {Level|MessageTemplate|IncrementedRowId}
+        /// </summary>
+        /// <param name="logEvent">the log event</param>
+        /// <param name="additionalRowKeyPostfix">suffix for the RowKey</param>
+        /// <returns>The generated RowKey</returns>
+        public override string GenerateRowKey(LogEvent logEvent, string additionalRowKeyPostfix = null)
+        {
+            var prefixBuilder = new StringBuilder(512);
+
+            // Join level and message template
+            prefixBuilder.Append(logEvent.Level).Append('|').Append(GetValidStringForTableKey(logEvent.MessageTemplate.Text));
+
+            var postfixBuilder = new StringBuilder(512);
+
+            if (additionalRowKeyPostfix != null)
+                postfixBuilder.Append('|').Append(GetValidStringForTableKey(additionalRowKeyPostfix));
+
+            // Append GUID to postfix
+            postfixBuilder.Append('|').Append(Guid.NewGuid());
+
+            // Truncate prefix if too long
+            var maxPrefixLength = 1024 - postfixBuilder.Length;
+            if (prefixBuilder.Length > maxPrefixLength)
+            {
+                prefixBuilder.Length = maxPrefixLength;
+            }
+
+            return prefixBuilder.Append(postfixBuilder).ToString();
+        }
+    }
+}

--- a/src/Serilog.Sinks.AzureTableStorage/project.json
+++ b/src/Serilog.Sinks.AzureTableStorage/project.json
@@ -9,8 +9,8 @@
     "iconUrl": "http://serilog.net/images/serilog-sink-nuget.png"
   },
   "dependencies": {
-    "Serilog": "2.0.0",
-    "Serilog.Sinks.PeriodicBatching": "2.0.0",
+    "Serilog": "2.3.0",
+    "Serilog.Sinks.PeriodicBatching": "2.1.0",
     "WindowsAzure.Storage": "7.2.0"
   },
   "buildOptions": {

--- a/test/Serilog.Sinks.AzureTableStorageWithProperties.Tests/AzureTableStorageEntityFactoryTests.cs
+++ b/test/Serilog.Sinks.AzureTableStorageWithProperties.Tests/AzureTableStorageEntityFactoryTests.cs
@@ -5,6 +5,7 @@ using Serilog.Parsing;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Serilog.Sinks.AzureTableStorage.Sinks.KeyGenerator;
 
 namespace Serilog.Sinks.AzureTableStorage.Tests
 {
@@ -26,11 +27,11 @@ namespace Serilog.Sinks.AzureTableStorage.Tests
 
             var logEvent = new Events.LogEvent(timestamp, level, exception, template, properties);
 
-            var entity = AzureTableStorageEntityFactory.CreateEntityWithProperties(logEvent, null, additionalRowKeyPostfix);
+            var keyGenerator = new PropertiesKeyGenerator();
+            var entity = AzureTableStorageEntityFactory.CreateEntityWithProperties(logEvent, null, additionalRowKeyPostfix, keyGenerator);
 
-            // Partition key
-            var expectedPartitionKey = "0" + new DateTime(logEvent.Timestamp.Year, logEvent.Timestamp.Month, logEvent.Timestamp.Day, logEvent.Timestamp.Hour, logEvent.Timestamp.Minute, 0).Ticks;
-            Assert.Equal(expectedPartitionKey, entity.PartitionKey);
+            // Make sure the partition key is in the expected format
+            Assert.Equal(entity.PartitionKey, "0" + new DateTime(long.Parse(entity.PartitionKey)).Ticks);
 
             // Row Key
             var expectedRowKeyWithoutGuid = "Information|Template {Temp} {Prop}|Some postfix|";
@@ -74,7 +75,7 @@ namespace Serilog.Sinks.AzureTableStorage.Tests
 
             var logEvent = new Events.LogEvent(timestamp, level, exception, template, properties);
 
-            var entity = AzureTableStorageEntityFactory.CreateEntityWithProperties(logEvent, null, additionalRowKeyPostfix);
+            var entity = AzureTableStorageEntityFactory.CreateEntityWithProperties(logEvent, null, additionalRowKeyPostfix, new PropertiesKeyGenerator());
 
             // Row Key
             var expectedRowKeyWithoutGuid = "Information|" + new string('x', messageSpace-4) + "ABCD|POSTFIX|";
@@ -118,7 +119,7 @@ namespace Serilog.Sinks.AzureTableStorage.Tests
 
             var logEvent = new Events.LogEvent(DateTime.Now, LogEventLevel.Information, null, template, properties);
 
-            var entity = AzureTableStorageEntityFactory.CreateEntityWithProperties(logEvent, null, null);
+            var entity = AzureTableStorageEntityFactory.CreateEntityWithProperties(logEvent, null, null, new PropertiesKeyGenerator());
 
             Assert.Equal(3 + properties.Count, entity.Properties.Count);
 
@@ -165,7 +166,7 @@ namespace Serilog.Sinks.AzureTableStorage.Tests
 
             var logEvent = new Events.LogEvent(DateTime.Now, LogEventLevel.Information, null, template, properties);
 
-            var entity = AzureTableStorageEntityFactory.CreateEntityWithProperties(logEvent, null, null);
+            var entity = AzureTableStorageEntityFactory.CreateEntityWithProperties(logEvent, null, null, new PropertiesKeyGenerator());
 
             Assert.Equal(3 + properties.Count, entity.Properties.Count);
             Assert.Equal("[(\"d1\": [(\"d1k1\": \"d1k1v1\"), (\"d1k2\": \"d1k2v2\"), (\"d1k3\": \"d1k3v3\")]), (\"d2\": [(\"d2k1\": \"d2k1v1\"), (\"d2k2\": \"d2k2v2\"), (\"d2k3\": \"d2k3v3\")]), (\"d0\": 0)]", entity.Properties["Dictionary"].StringValue);
@@ -208,7 +209,7 @@ namespace Serilog.Sinks.AzureTableStorage.Tests
 
             var logEvent = new Events.LogEvent(DateTime.Now, LogEventLevel.Information, null, template, properties);
 
-            var entity = AzureTableStorageEntityFactory.CreateEntityWithProperties(logEvent, null, null);
+            var entity = AzureTableStorageEntityFactory.CreateEntityWithProperties(logEvent, null, null, new PropertiesKeyGenerator());
 
             Assert.Equal(3 + properties.Count, entity.Properties.Count);
             Assert.Equal("[[1, 2, 3, 4, 5], [\"a\", \"b\", \"c\", \"d\", \"e\"]]", entity.Properties["Sequence"].StringValue);
@@ -233,7 +234,7 @@ namespace Serilog.Sinks.AzureTableStorage.Tests
 
             var logEvent = new Events.LogEvent(DateTime.Now, LogEventLevel.Information, null, template, properties);
 
-            var entity = AzureTableStorageEntityFactory.CreateEntityWithProperties(logEvent, null, null);
+            var entity = AzureTableStorageEntityFactory.CreateEntityWithProperties(logEvent, null, null, new PropertiesKeyGenerator());
 
             Assert.Equal(252, entity.Properties.Count);
             Assert.Contains("AggregatedProperties", entity.Properties.Keys.ToList());


### PR DESCRIPTION
Goal was to bring the "WithProperties" sinks and extensions in line with the latest key generator changes and to make working with the DefaultKeyGenerator easier.

- added new PropertiesKeyGenerator for RowKey format formerly generated by the factory class
- changed DefaultKeyGenerator to public class with virtual methods
- modified the IKeyGenerator interface GenerateRowKey method to support optional suffix parameter
- updated unit tests to work with new constructors and method signatures. modified one assertion based on key generator changes.
- updated serilog versions and modified nuspec