### PR TITLE
Allows use of numeric properties

### DIFF
--- a/src/Serilog.Sinks.AzureTableStorage/Sinks/AzureTableStorageWithProperties/AzureTableStorageEntityFactory.cs
+++ b/src/Serilog.Sinks.AzureTableStorage/Sinks/AzureTableStorageWithProperties/AzureTableStorageEntityFactory.cs
@@ -61,9 +61,15 @@ namespace Serilog.Sinks.AzureTableStorage
 
             List<KeyValuePair<ScalarValue, LogEventPropertyValue>> additionalData = null;
             var count = dynamicProperties.Count;
+			bool isNumeric;
+			int parsedNumber;
+
             foreach (var logProperty in logEvent.Properties)
             {
-                if (count++ < _maxNumberOfPropertiesPerRow - 1)
+				isNumeric = int.TryParse(logProperty.Key, out parsedNumber);
+
+				// Don't add table properties for numeric property names
+                if (!isNumeric && (count++ < _maxNumberOfPropertiesPerRow - 1))
                 {
                     dynamicProperties.Add(logProperty.Key, AzurePropertyFormatter.ToEntityProperty(logProperty.Value, null, formatProvider));
                 }

--- a/src/Serilog.Sinks.AzureTableStorage/project.json
+++ b/src/Serilog.Sinks.AzureTableStorage/project.json
@@ -10,8 +10,7 @@
   },
   "dependencies": {
     "Serilog": "2.3.0",
-    "Serilog.Sinks.PeriodicBatching": "2.1.0",
-    "WindowsAzure.Storage": "7.2.0"
+    "Serilog.Sinks.PeriodicBatching": "2.1.0"
   },
   "buildOptions": {
     "keyFile": "../../assets/Serilog.snk"
@@ -20,9 +19,15 @@
     "net4.5": {
       "frameworkAssemblies": {
         "System.Configuration": ""
+      },
+      "dependencies": {
+        "WindowsAzure.Storage": "6.2.0"
       }
     },
     "netstandard1.3": {
+      "dependencies": {
+        "WindowsAzure.Storage": "7.2.0"
+      },
       "imports": [
         "portable-net45+win8+wp8+wpa81"
       ]

--- a/test/Serilog.Sinks.AzureTableStorageWithProperties.Tests/AzureTableStorageWithPropertiesSinkTests.cs
+++ b/test/Serilog.Sinks.AzureTableStorageWithProperties.Tests/AzureTableStorageWithPropertiesSinkTests.cs
@@ -214,55 +214,52 @@ namespace Serilog.Sinks.AzureTableStorage.Tests
             Assert.Equal("Struct0 { Struct1Val: Struct1 { IntVal: 10, StringVal: \"ABCDE\" }, Struct2Val: Struct2 { DateTimeVal: 12/03/2014 17:37:12, DoubleVal: 3.14159265358979 } }", result.Properties["Struct0"].StringValue);
         }
 
-		[Fact]
-		public async Task WhenALoggerWritesToTheSinkItAllowsStringFormatNumericPropertyNames()
-		{
-			var storageAccount = CloudStorageAccount.DevelopmentStorageAccount;
-			var tableClient = storageAccount.CreateCloudTableClient();
-			var table = tableClient.GetTableReference("LogEventEntity");
+        [Fact]
+        public async Task WhenALoggerWritesToTheSinkItAllowsStringFormatNumericPropertyNames()
+        {
+            var storageAccount = CloudStorageAccount.DevelopmentStorageAccount;
+            var tableClient = storageAccount.CreateCloudTableClient();
+            var table = tableClient.GetTableReference("LogEventEntity");
 
-			await table.DeleteIfExistsAsync();
+            await table.DeleteIfExistsAsync();
 
-			var logger = new LoggerConfiguration()
-				.WriteTo.AzureTableStorageWithProperties(storageAccount)
-				.CreateLogger();
+            var logger = new LoggerConfiguration()
+                .WriteTo.AzureTableStorageWithProperties(storageAccount)
+                .CreateLogger();
 
-			var formatString = "Hello {0}";
-			var formatParam = "world";
-			var expectedResult = "Hello \"world\"";
+            var expectedResult = "Hello \"world\"";
 
-			logger.Information(formatString, formatParam);
-			var result = (await TableQueryTakeDynamicAsync(table, takeCount: 1)).First();
+            logger.Information("Hello {0}", "world");
+            var result = (await TableQueryTakeDynamicAsync(table, takeCount: 1)).First();
 
-			Assert.Equal(expectedResult, result.Properties["RenderedMessage"].StringValue);
-		}
+            Assert.Equal(expectedResult, result.Properties["RenderedMessage"].StringValue);
+        }
 
-		[Fact]
-		public async Task WhenALoggerWritesToTheSinkItAllowsNamedAndNumericPropertyNames()
-		{
-			var storageAccount = CloudStorageAccount.DevelopmentStorageAccount;
-			var tableClient = storageAccount.CreateCloudTableClient();
-			var table = tableClient.GetTableReference("LogEventEntity");
+        [Fact]
+        public async Task WhenALoggerWritesToTheSinkItAllowsNamedAndNumericPropertyNames()
+        {
+            var storageAccount = CloudStorageAccount.DevelopmentStorageAccount;
+            var tableClient = storageAccount.CreateCloudTableClient();
+            var table = tableClient.GetTableReference("LogEventEntity");
 
-			await table.DeleteIfExistsAsync();
+            await table.DeleteIfExistsAsync();
 
-			var logger = new LoggerConfiguration()
-				.WriteTo.AzureTableStorageWithProperties(storageAccount)
-				.CreateLogger();
+            var logger = new LoggerConfiguration()
+                .WriteTo.AzureTableStorageWithProperties(storageAccount)
+                .CreateLogger();
 
-			var formatString = "Hello {0} this is {Name}";
-			var formatParam = "world";
-			var formatName = "John Smith";
-			var expectedResult = "Hello \"world\" this is \"John Smith\"";
+            var name = "John Smith";
+            var expectedResult = "Hello \"world\" this is \"John Smith\" 1234";
 
-			logger.Information(formatString, formatParam, formatName);
-			var result = (await TableQueryTakeDynamicAsync(table, takeCount: 1)).First();
+            logger.Information("Hello {0} this is {Name} {_1234}", "world", name, 1234);
+            var result = (await TableQueryTakeDynamicAsync(table, takeCount: 1)).First();
 
-			Assert.Equal(expectedResult, result.Properties["RenderedMessage"].StringValue);
-			Assert.Equal(formatName, result.Properties["Name"].StringValue);
-		}
+            Assert.Equal(expectedResult, result.Properties["RenderedMessage"].StringValue);
+            Assert.Equal(name, result.Properties["Name"].StringValue);
+            Assert.Equal(1234, result.Properties["_1234"].Int32Value);
+        }
 
-		[Fact]
+        [Fact]
         public async Task WhenABatchLoggerWritesToTheSinkItStoresAllTheEntries()
         {
             var storageAccount = CloudStorageAccount.DevelopmentStorageAccount;

--- a/test/Serilog.Sinks.AzureTableStorageWithProperties.Tests/project.json
+++ b/test/Serilog.Sinks.AzureTableStorageWithProperties.Tests/project.json
@@ -11,9 +11,6 @@
     "keyFile": "../../assets/Serilog.snk"
   },
   "frameworks": {
-    "net4.5.2": {
-
-    },
     "netcoreapp1.0": {
       "imports": [
         "portable-net45+win8+wp8+wpa81"
@@ -24,6 +21,9 @@
           "version": "1.0.0"
         }
       }
+    },
+    "net4.5.2": {
+
     }
   }
 }


### PR DESCRIPTION
The [Serilog wiki](https://github.com/serilog/serilog/wiki/Writing-Log-Events#message-template-syntax) states:

> - Formats that use numeric property names, like {0} and {1} exclusively, will be matched with the log method's parameters by treating the property names as indexes; this is identical to string.Format()'s behaviour
> - If any of the property names are non-numeric, then all property names will be matched from left-to-right with the log method's parameters

However, when calling `log.Information("Hello {0}", name);` this causes an Azure storage exception as columns in Azure Table Storage must follow [naming rules for C# identifiers](https://blogs.msdn.microsoft.com/jmstall/2014/06/12/azure-storage-naming-rules/) and the name `0` is invalid.

This fix updates the code so that if it detects a numeric property name, it won't attempt to add that as a separate property to table storage. However, for completeness the property is added to the `AggregatedProperties` table property. It also supports mixed use of numeric and named properties.