### PR TITLE
Makes Azure Storage dependency version framework-specific

### DIFF
--- a/src/Serilog.Sinks.AzureTableStorage/project.json
+++ b/src/Serilog.Sinks.AzureTableStorage/project.json
@@ -10,8 +10,7 @@
   },
   "dependencies": {
     "Serilog": "2.3.0",
-    "Serilog.Sinks.PeriodicBatching": "2.1.0",
-    "WindowsAzure.Storage": "7.2.0"
+    "Serilog.Sinks.PeriodicBatching": "2.1.0"
   },
   "buildOptions": {
     "keyFile": "../../assets/Serilog.snk"
@@ -20,9 +19,15 @@
     "net4.5": {
       "frameworkAssemblies": {
         "System.Configuration": ""
+      },
+      "dependencies": {
+        "WindowsAzure.Storage": "6.2.0"
       }
     },
     "netstandard1.3": {
+      "dependencies": {
+        "WindowsAzure.Storage": "7.2.0"
+      },
       "imports": [
         "portable-net45+win8+wp8+wpa81"
       ]


### PR DESCRIPTION
This changes removes `Windows.AzureStorage` version `7.2.0` as an overall dependency and instead adds two framework-specific dependencies: version `6.2.0` for .NET 4.5 and version `7.2.0` for .NET Standard. This allows .NET 4.5 projects to continue using the prior framework version.