### PR TITLE
Added functionality to provide Specific Properties to be written to Azure Table Storage

### DIFF
--- a/src/Serilog.Sinks.AzureTableStorage/LoggerConfigurationAzureTableStorageWithPropertiesExtensions.cs
+++ b/src/Serilog.Sinks.AzureTableStorage/LoggerConfigurationAzureTableStorageWithPropertiesExtensions.cs
@@ -52,7 +52,7 @@ namespace Serilog
         /// <param name="period">The time to wait between checking for event batches.</param>
         /// <param name="additionalRowKeyPostfix">Additional postfix string that will be appended to row keys</param>
         /// <param name="keyGenerator">Generates the PartitionKey and the RowKey</param>
-        /// <param name="specificProperties">Specific properties to be added to the Table Storage</param>
+        /// <param name="propertyColumns">Specific properties to be written to columns. By default, all properties will be written to columns.</param>
         /// <returns>Logger configuration, allowing configuration to continue.</returns>
         /// <exception cref="ArgumentNullException">A required parameter is null.</exception>
         public static LoggerConfiguration AzureTableStorageWithProperties(
@@ -66,7 +66,7 @@ namespace Serilog
             int? batchPostingLimit = null,
             string additionalRowKeyPostfix = null,
             IKeyGenerator keyGenerator = null,
-            string[] specificProperties = null)
+            string[] propertyColumns = null)
         {
             if (loggerConfiguration == null) throw new ArgumentNullException("loggerConfiguration");
             if (storageAccount == null) throw new ArgumentNullException("storageAccount");
@@ -77,8 +77,8 @@ namespace Serilog
             {
                 sink = writeInBatches
                     ? (ILogEventSink)
-                    new AzureBatchingTableStorageWithPropertiesSink(storageAccount, formatProvider, batchPostingLimit ?? DefaultBatchPostingLimit, period ?? DefaultPeriod, storageTableName, additionalRowKeyPostfix, keyGenerator, specificProperties)
-                    : new AzureTableStorageWithPropertiesSink(storageAccount, formatProvider, storageTableName, additionalRowKeyPostfix, keyGenerator, specificProperties);
+                    new AzureBatchingTableStorageWithPropertiesSink(storageAccount, formatProvider, batchPostingLimit ?? DefaultBatchPostingLimit, period ?? DefaultPeriod, storageTableName, additionalRowKeyPostfix, keyGenerator, propertyColumns)
+                    : new AzureTableStorageWithPropertiesSink(storageAccount, formatProvider, storageTableName, additionalRowKeyPostfix, keyGenerator, propertyColumns);
             }
             catch (Exception ex)
             {
@@ -103,7 +103,7 @@ namespace Serilog
         /// <param name="period">The time to wait between checking for event batches.</param>
         /// <param name="additionalRowKeyPostfix">Additional postfix string that will be appended to row keys</param>
         /// <param name="keyGenerator">Generates the PartitionKey and the RowKey</param>
-        /// <param name="specificProperties">Specific properties only to be added to the Table Storage</param>
+        /// <param name="propertyColumns">Specific properties to be written to columns. By default, all properties will be written to columns.</param>
         /// <returns>Logger configuration, allowing configuration to continue.</returns>
         /// <exception cref="ArgumentNullException">A required parameter is null.</exception>
         public static LoggerConfiguration AzureTableStorageWithProperties(
@@ -117,7 +117,7 @@ namespace Serilog
             int? batchPostingLimit = null,
             string additionalRowKeyPostfix = null,
             IKeyGenerator keyGenerator = null, 
-            string[] specificProperties = null)
+            string[] propertyColumns = null)
         {
             if (loggerConfiguration == null) throw new ArgumentNullException("loggerConfiguration");
             if (String.IsNullOrEmpty(connectionString)) throw new ArgumentNullException("connectionString");
@@ -125,7 +125,7 @@ namespace Serilog
             try
             {
                 var storageAccount = CloudStorageAccount.Parse(connectionString);
-                return AzureTableStorageWithProperties(loggerConfiguration, storageAccount, restrictedToMinimumLevel, formatProvider, storageTableName, writeInBatches, period, batchPostingLimit, additionalRowKeyPostfix, keyGenerator, specificProperties);
+                return AzureTableStorageWithProperties(loggerConfiguration, storageAccount, restrictedToMinimumLevel, formatProvider, storageTableName, writeInBatches, period, batchPostingLimit, additionalRowKeyPostfix, keyGenerator, propertyColumns);
             }
             catch (Exception ex)
             {

--- a/src/Serilog.Sinks.AzureTableStorage/LoggerConfigurationAzureTableStorageWithPropertiesExtensions.cs
+++ b/src/Serilog.Sinks.AzureTableStorage/LoggerConfigurationAzureTableStorageWithPropertiesExtensions.cs
@@ -18,11 +18,7 @@ using Serilog.Core;
 using Serilog.Events;
 using Serilog.Sinks.AzureTableStorage;
 using System;
-using System.Collections;
-using System.Collections.Generic;
 using Serilog.Sinks.AzureTableStorage.KeyGenerator;
-using Serilog.Sinks.AzureTableStorage.Sinks.KeyGenerator;
-using Serilog.Sinks.AzureTableStorage.Sinks;
 
 namespace Serilog
 {
@@ -57,8 +53,6 @@ namespace Serilog
         /// <param name="additionalRowKeyPostfix">Additional postfix string that will be appended to row keys</param>
         /// <param name="keyGenerator">Generates the PartitionKey and the RowKey</param>
         /// <param name="specificProperties">Specific properties to be added to the Table Storage</param>
-        /// <param name="onlySpecificProperties">Only configure the specific properties specified; otherwise, all properties provided 
-        /// in the message templates will be created</param>
         /// <returns>Logger configuration, allowing configuration to continue.</returns>
         /// <exception cref="ArgumentNullException">A required parameter is null.</exception>
         public static LoggerConfiguration AzureTableStorageWithProperties(
@@ -72,8 +66,7 @@ namespace Serilog
             int? batchPostingLimit = null,
             string additionalRowKeyPostfix = null,
             IKeyGenerator keyGenerator = null,
-            string[] specificProperties = null,
-            bool onlySpecificProperties = false)
+            string[] specificProperties = null)
         {
             if (loggerConfiguration == null) throw new ArgumentNullException("loggerConfiguration");
             if (storageAccount == null) throw new ArgumentNullException("storageAccount");
@@ -84,8 +77,8 @@ namespace Serilog
             {
                 sink = writeInBatches
                     ? (ILogEventSink)
-                    new AzureBatchingTableStorageWithPropertiesSink(storageAccount, formatProvider, batchPostingLimit ?? DefaultBatchPostingLimit, period ?? DefaultPeriod, storageTableName, additionalRowKeyPostfix, keyGenerator, specificProperties, onlySpecificProperties)
-                    : new AzureTableStorageWithPropertiesSink(storageAccount, formatProvider, storageTableName, additionalRowKeyPostfix, keyGenerator, specificProperties, onlySpecificProperties);
+                    new AzureBatchingTableStorageWithPropertiesSink(storageAccount, formatProvider, batchPostingLimit ?? DefaultBatchPostingLimit, period ?? DefaultPeriod, storageTableName, additionalRowKeyPostfix, keyGenerator, specificProperties)
+                    : new AzureTableStorageWithPropertiesSink(storageAccount, formatProvider, storageTableName, additionalRowKeyPostfix, keyGenerator, specificProperties);
             }
             catch (Exception ex)
             {
@@ -110,9 +103,7 @@ namespace Serilog
         /// <param name="period">The time to wait between checking for event batches.</param>
         /// <param name="additionalRowKeyPostfix">Additional postfix string that will be appended to row keys</param>
         /// <param name="keyGenerator">Generates the PartitionKey and the RowKey</param>
-        /// <param name="specificProperties">Specific properties to be added to the Table Storage</param>
-        /// <param name="onlySpecificProperties">Only configure the specific properties specified; otherwise, all properties provided 
-        /// in the message templates will be created</param>
+        /// <param name="specificProperties">Specific properties only to be added to the Table Storage</param>
         /// <returns>Logger configuration, allowing configuration to continue.</returns>
         /// <exception cref="ArgumentNullException">A required parameter is null.</exception>
         public static LoggerConfiguration AzureTableStorageWithProperties(
@@ -126,8 +117,7 @@ namespace Serilog
             int? batchPostingLimit = null,
             string additionalRowKeyPostfix = null,
             IKeyGenerator keyGenerator = null, 
-            string[] specificProperties = null,
-            bool onlySpecificProperties = false)
+            string[] specificProperties = null)
         {
             if (loggerConfiguration == null) throw new ArgumentNullException("loggerConfiguration");
             if (String.IsNullOrEmpty(connectionString)) throw new ArgumentNullException("connectionString");
@@ -135,7 +125,7 @@ namespace Serilog
             try
             {
                 var storageAccount = CloudStorageAccount.Parse(connectionString);
-                return AzureTableStorageWithProperties(loggerConfiguration, storageAccount, restrictedToMinimumLevel, formatProvider, storageTableName, writeInBatches, period, batchPostingLimit, additionalRowKeyPostfix, keyGenerator, specificProperties, onlySpecificProperties);
+                return AzureTableStorageWithProperties(loggerConfiguration, storageAccount, restrictedToMinimumLevel, formatProvider, storageTableName, writeInBatches, period, batchPostingLimit, additionalRowKeyPostfix, keyGenerator, specificProperties);
             }
             catch (Exception ex)
             {

--- a/src/Serilog.Sinks.AzureTableStorage/LoggerConfigurationAzureTableStorageWithPropertiesExtensions.cs
+++ b/src/Serilog.Sinks.AzureTableStorage/LoggerConfigurationAzureTableStorageWithPropertiesExtensions.cs
@@ -18,6 +18,8 @@ using Serilog.Core;
 using Serilog.Events;
 using Serilog.Sinks.AzureTableStorage;
 using System;
+using System.Collections;
+using System.Collections.Generic;
 using Serilog.Sinks.AzureTableStorage.KeyGenerator;
 using Serilog.Sinks.AzureTableStorage.Sinks.KeyGenerator;
 using Serilog.Sinks.AzureTableStorage.Sinks;
@@ -54,7 +56,9 @@ namespace Serilog
         /// <param name="period">The time to wait between checking for event batches.</param>
         /// <param name="additionalRowKeyPostfix">Additional postfix string that will be appended to row keys</param>
         /// <param name="keyGenerator">Generates the PartitionKey and the RowKey</param>
-        /// <param name="propagateExceptions">Whether connection issues should throw an exception; disabled by default.</param>
+        /// <param name="specificProperties">Specific properties to be added to the Table Storage</param>
+        /// <param name="onlySpecificProperties">Only configure the specific properties specified; otherwise, all properties provided 
+        /// in the message templates will be created</param>
         /// <returns>Logger configuration, allowing configuration to continue.</returns>
         /// <exception cref="ArgumentNullException">A required parameter is null.</exception>
         public static LoggerConfiguration AzureTableStorageWithProperties(
@@ -67,7 +71,9 @@ namespace Serilog
             TimeSpan? period = null,
             int? batchPostingLimit = null,
             string additionalRowKeyPostfix = null,
-            IKeyGenerator keyGenerator = null)
+            IKeyGenerator keyGenerator = null,
+            string[] specificProperties = null,
+            bool onlySpecificProperties = false)
         {
             if (loggerConfiguration == null) throw new ArgumentNullException("loggerConfiguration");
             if (storageAccount == null) throw new ArgumentNullException("storageAccount");
@@ -78,8 +84,8 @@ namespace Serilog
             {
                 sink = writeInBatches
                     ? (ILogEventSink)
-                    new AzureBatchingTableStorageWithPropertiesSink(storageAccount, formatProvider, batchPostingLimit ?? DefaultBatchPostingLimit, period ?? DefaultPeriod, storageTableName, additionalRowKeyPostfix, keyGenerator)
-                    : new AzureTableStorageWithPropertiesSink(storageAccount, formatProvider, storageTableName, additionalRowKeyPostfix, keyGenerator);
+                    new AzureBatchingTableStorageWithPropertiesSink(storageAccount, formatProvider, batchPostingLimit ?? DefaultBatchPostingLimit, period ?? DefaultPeriod, storageTableName, additionalRowKeyPostfix, keyGenerator, specificProperties, onlySpecificProperties)
+                    : new AzureTableStorageWithPropertiesSink(storageAccount, formatProvider, storageTableName, additionalRowKeyPostfix, keyGenerator, specificProperties, onlySpecificProperties);
             }
             catch (Exception ex)
             {
@@ -104,6 +110,9 @@ namespace Serilog
         /// <param name="period">The time to wait between checking for event batches.</param>
         /// <param name="additionalRowKeyPostfix">Additional postfix string that will be appended to row keys</param>
         /// <param name="keyGenerator">Generates the PartitionKey and the RowKey</param>
+        /// <param name="specificProperties">Specific properties to be added to the Table Storage</param>
+        /// <param name="onlySpecificProperties">Only configure the specific properties specified; otherwise, all properties provided 
+        /// in the message templates will be created</param>
         /// <returns>Logger configuration, allowing configuration to continue.</returns>
         /// <exception cref="ArgumentNullException">A required parameter is null.</exception>
         public static LoggerConfiguration AzureTableStorageWithProperties(
@@ -116,7 +125,9 @@ namespace Serilog
             TimeSpan? period = null,
             int? batchPostingLimit = null,
             string additionalRowKeyPostfix = null,
-            IKeyGenerator keyGenerator = null)
+            IKeyGenerator keyGenerator = null, 
+            string[] specificProperties = null,
+            bool onlySpecificProperties = false)
         {
             if (loggerConfiguration == null) throw new ArgumentNullException("loggerConfiguration");
             if (String.IsNullOrEmpty(connectionString)) throw new ArgumentNullException("connectionString");
@@ -124,7 +135,7 @@ namespace Serilog
             try
             {
                 var storageAccount = CloudStorageAccount.Parse(connectionString);
-                return AzureTableStorageWithProperties(loggerConfiguration, storageAccount, restrictedToMinimumLevel, formatProvider, storageTableName, writeInBatches, period, batchPostingLimit, additionalRowKeyPostfix, keyGenerator);
+                return AzureTableStorageWithProperties(loggerConfiguration, storageAccount, restrictedToMinimumLevel, formatProvider, storageTableName, writeInBatches, period, batchPostingLimit, additionalRowKeyPostfix, keyGenerator, specificProperties, onlySpecificProperties);
             }
             catch (Exception ex)
             {

--- a/src/Serilog.Sinks.AzureTableStorage/Sinks/AzureTableStorageWithProperties/AzureBatchingTableStorageWithPropertiesSink.cs
+++ b/src/Serilog.Sinks.AzureTableStorage/Sinks/AzureTableStorageWithProperties/AzureBatchingTableStorageWithPropertiesSink.cs
@@ -34,7 +34,7 @@ namespace Serilog.Sinks.AzureTableStorage
         private readonly IFormatProvider _formatProvider;
         private readonly CloudTable _table;
         private readonly string _additionalRowKeyPostfix;
-        private readonly string[] _specificProperties;
+        private readonly string[] _propertyColumns;
         private const int _maxAzureOperationsPerBatch = 100;
         private readonly IKeyGenerator _keyGenerator;
 
@@ -48,7 +48,7 @@ namespace Serilog.Sinks.AzureTableStorage
         /// <param name="storageTableName">Table name that log entries will be written to. Note: Optional, setting this may impact performance</param>
         /// <param name="additionalRowKeyPostfix">Additional postfix string that will be appended to row keys</param>
         /// <param name="keyGenerator">Generates the PartitionKey and the RowKey</param>
-        /// <param name="specificProperties">Specific properties only to be added to the Table Storage</param>
+        /// <param name="propertyColumns">Specific properties to be written to columns. By default, all properties will be written to columns.</param>
         /// <returns>Logger configuration, allowing configuration to continue.</returns>
         public AzureBatchingTableStorageWithPropertiesSink(CloudStorageAccount storageAccount,
             IFormatProvider formatProvider,
@@ -57,7 +57,7 @@ namespace Serilog.Sinks.AzureTableStorage
             string storageTableName = null,
             string additionalRowKeyPostfix = null,
             IKeyGenerator keyGenerator = null, 
-            string[] specificProperties = null)
+            string[] propertyColumns = null)
             : base(batchSizeLimit, period)
         {
             var tableClient = storageAccount.CreateCloudTableClient();
@@ -72,7 +72,7 @@ namespace Serilog.Sinks.AzureTableStorage
 
             _formatProvider = formatProvider;
             _additionalRowKeyPostfix = additionalRowKeyPostfix;
-            _specificProperties = specificProperties;
+            _propertyColumns = propertyColumns;
             _keyGenerator = keyGenerator ?? new PropertiesKeyGenerator();
         }
 
@@ -84,7 +84,7 @@ namespace Serilog.Sinks.AzureTableStorage
 
             foreach (var logEvent in events)
             {
-                var tableEntity = AzureTableStorageEntityFactory.CreateEntityWithProperties(logEvent, _formatProvider, _additionalRowKeyPostfix, _keyGenerator, _specificProperties);
+                var tableEntity = AzureTableStorageEntityFactory.CreateEntityWithProperties(logEvent, _formatProvider, _additionalRowKeyPostfix, _keyGenerator, _propertyColumns);
 
                 // If partition changed, store the new and force an execution
                 if (lastPartitionKey != tableEntity.PartitionKey)

--- a/src/Serilog.Sinks.AzureTableStorage/Sinks/AzureTableStorageWithProperties/AzureBatchingTableStorageWithPropertiesSink.cs
+++ b/src/Serilog.Sinks.AzureTableStorage/Sinks/AzureTableStorageWithProperties/AzureBatchingTableStorageWithPropertiesSink.cs
@@ -35,7 +35,6 @@ namespace Serilog.Sinks.AzureTableStorage
         private readonly CloudTable _table;
         private readonly string _additionalRowKeyPostfix;
         private readonly string[] _specificProperties;
-        private readonly bool _onlySpecificProperties;
         private const int _maxAzureOperationsPerBatch = 100;
         private readonly IKeyGenerator _keyGenerator;
 
@@ -49,9 +48,7 @@ namespace Serilog.Sinks.AzureTableStorage
         /// <param name="storageTableName">Table name that log entries will be written to. Note: Optional, setting this may impact performance</param>
         /// <param name="additionalRowKeyPostfix">Additional postfix string that will be appended to row keys</param>
         /// <param name="keyGenerator">Generates the PartitionKey and the RowKey</param>
-        /// <param name="specificProperties">Specific properties to be added to the Table Storage</param>
-        /// <param name="onlySpecificProperties">Only configure the specific properties specified; otherwise, all properties provided 
-        /// in the message templates will be created</param>
+        /// <param name="specificProperties">Specific properties only to be added to the Table Storage</param>
         /// <returns>Logger configuration, allowing configuration to continue.</returns>
         public AzureBatchingTableStorageWithPropertiesSink(CloudStorageAccount storageAccount,
             IFormatProvider formatProvider,
@@ -60,8 +57,7 @@ namespace Serilog.Sinks.AzureTableStorage
             string storageTableName = null,
             string additionalRowKeyPostfix = null,
             IKeyGenerator keyGenerator = null, 
-            string[] specificProperties = null, 
-            bool onlySpecificProperties = false)
+            string[] specificProperties = null)
             : base(batchSizeLimit, period)
         {
             var tableClient = storageAccount.CreateCloudTableClient();
@@ -77,7 +73,6 @@ namespace Serilog.Sinks.AzureTableStorage
             _formatProvider = formatProvider;
             _additionalRowKeyPostfix = additionalRowKeyPostfix;
             _specificProperties = specificProperties;
-            _onlySpecificProperties = onlySpecificProperties;
             _keyGenerator = keyGenerator ?? new PropertiesKeyGenerator();
         }
 
@@ -89,7 +84,7 @@ namespace Serilog.Sinks.AzureTableStorage
 
             foreach (var logEvent in events)
             {
-                var tableEntity = AzureTableStorageEntityFactory.CreateEntityWithProperties(logEvent, _formatProvider, _additionalRowKeyPostfix, _keyGenerator, _specificProperties, _onlySpecificProperties);
+                var tableEntity = AzureTableStorageEntityFactory.CreateEntityWithProperties(logEvent, _formatProvider, _additionalRowKeyPostfix, _keyGenerator, _specificProperties);
 
                 // If partition changed, store the new and force an execution
                 if (lastPartitionKey != tableEntity.PartitionKey)

--- a/src/Serilog.Sinks.AzureTableStorage/Sinks/AzureTableStorageWithProperties/AzureTableStorageEntityFactory.cs
+++ b/src/Serilog.Sinks.AzureTableStorage/Sinks/AzureTableStorageWithProperties/AzureTableStorageEntityFactory.cs
@@ -39,9 +39,9 @@ namespace Serilog.Sinks.AzureTableStorage
         /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
         /// <param name="additionalRowKeyPostfix">Additional postfix string that will be appended to row keys</param>
         /// <param name="keyGenerator">The IKeyGenerator for the PartitionKey and RowKey</param>
-        /// <param name="specificProperties">Specific properties to be added to the table entity</param>
+        /// <param name="propertyColumns">Specific properties to be written to columns. By default, all properties will be written to columns.</param>
         /// <returns></returns>
-        public static DynamicTableEntity CreateEntityWithProperties(LogEvent logEvent, IFormatProvider formatProvider, string additionalRowKeyPostfix, IKeyGenerator keyGenerator, string[] specificProperties = null)
+        public static DynamicTableEntity CreateEntityWithProperties(LogEvent logEvent, IFormatProvider formatProvider, string additionalRowKeyPostfix, IKeyGenerator keyGenerator, string[] propertyColumns = null)
         {
             var tableEntity = new DynamicTableEntity
             {
@@ -67,7 +67,7 @@ namespace Serilog.Sinks.AzureTableStorage
 
             foreach (var logProperty in logEvent.Properties)
             {
-                isValid = IsValidColumnName(logProperty.Key) && IsValidSpecificColumn(logProperty.Key, specificProperties);
+                isValid = IsValidColumnName(logProperty.Key) && ShouldIncludeProperty(logProperty.Key, propertyColumns);
 
                 // Don't add table properties for numeric property names
                 if (isValid && (count++ < _maxNumberOfPropertiesPerRow - 1))
@@ -110,11 +110,11 @@ namespace Serilog.Sinks.AzureTableStorage
         /// Note: If specific columns is not defined then the property name is considered valid. 
         /// </summary>
         /// <param name="propertyName">Name of the property to check</param>
-        /// <param name="specificProperties">List of defined properties only to be added as columns</param>
-        /// <returns>true if the no specificColumns are specified or it is included in the specificColumns property</returns>
-        private static bool IsValidSpecificColumn(string propertyName, string[] specificProperties)
+        /// <param name="propertyColumns">List of defined properties only to be added as columns</param>
+        /// <returns>true if the no propertyColumns are specified or it is included in the propertyColumns property</returns>
+        private static bool ShouldIncludeProperty(string propertyName, string[] propertyColumns)
         {
-            return specificProperties == null || specificProperties.Contains(propertyName);
+            return propertyColumns == null || propertyColumns.Contains(propertyName);
         }
     }
 }

--- a/src/Serilog.Sinks.AzureTableStorage/Sinks/AzureTableStorageWithProperties/AzureTableStorageEntityFactory.cs
+++ b/src/Serilog.Sinks.AzureTableStorage/Sinks/AzureTableStorageWithProperties/AzureTableStorageEntityFactory.cs
@@ -40,10 +40,8 @@ namespace Serilog.Sinks.AzureTableStorage
         /// <param name="additionalRowKeyPostfix">Additional postfix string that will be appended to row keys</param>
         /// <param name="keyGenerator">The IKeyGenerator for the PartitionKey and RowKey</param>
         /// <param name="specificProperties">Specific properties to be added to the table entity</param>
-        /// <param name="onlySpecificProperties">Only configure the specific properties specified; otherwise, all properties provided 
-        /// in the logEvent will be created</param>
         /// <returns></returns>
-        public static DynamicTableEntity CreateEntityWithProperties(LogEvent logEvent, IFormatProvider formatProvider, string additionalRowKeyPostfix, IKeyGenerator keyGenerator, string[] specificProperties = null, bool onlySpecificProperties = false)
+        public static DynamicTableEntity CreateEntityWithProperties(LogEvent logEvent, IFormatProvider formatProvider, string additionalRowKeyPostfix, IKeyGenerator keyGenerator, string[] specificProperties = null)
         {
             var tableEntity = new DynamicTableEntity
             {
@@ -69,7 +67,7 @@ namespace Serilog.Sinks.AzureTableStorage
 
             foreach (var logProperty in logEvent.Properties)
             {
-                isValid = IsValidColumnName(logProperty.Key) && IsSpecificColumn(logProperty.Key, onlySpecificProperties, specificProperties);
+                isValid = IsValidColumnName(logProperty.Key) && IsValidSpecificColumn(logProperty.Key, specificProperties);
 
                 // Don't add table properties for numeric property names
                 if (isValid && (count++ < _maxNumberOfPropertiesPerRow - 1))
@@ -108,15 +106,15 @@ namespace Serilog.Sinks.AzureTableStorage
         }
 
         /// <summary>
-        /// Determines whether or not the given property names conforms to naming rules for C# identifiers
+        /// Determines if the given property name exists in the specific columns. 
+        /// Note: If specific columns is not defined then the property name is considered valid. 
         /// </summary>
         /// <param name="propertyName">Name of the property to check</param>
-        /// <param name="specificColumns"></param>
-        /// <param name="onlySpecificColumns"></param>
-        /// <returns>true if the property name conforms to C# identifier naming rules and can therefore be added as a table property</returns>
-        private static bool IsSpecificColumn(string propertyName, bool onlySpecificColumns, IEnumerable<string> specificColumns)
+        /// <param name="specificProperties">List of defined properties only to be added as columns</param>
+        /// <returns>true if the no specificColumns are specified or it is included in the specificColumns property</returns>
+        private static bool IsValidSpecificColumn(string propertyName, string[] specificProperties)
         {
-            return !onlySpecificColumns || (specificColumns != null && specificColumns.Contains(propertyName));
+            return specificProperties == null || specificProperties.Contains(propertyName);
         }
     }
 }

--- a/src/Serilog.Sinks.AzureTableStorage/Sinks/AzureTableStorageWithProperties/AzureTableStorageWithPropertiesSink.cs
+++ b/src/Serilog.Sinks.AzureTableStorage/Sinks/AzureTableStorageWithProperties/AzureTableStorageWithPropertiesSink.cs
@@ -34,7 +34,6 @@ namespace Serilog.Sinks.AzureTableStorage
         private readonly CloudTable _table;
         private readonly string _additionalRowKeyPostfix;
         private readonly string[] _specificProperties;
-        private readonly bool _onlySpecificProperties;
         private readonly IKeyGenerator _keyGenerator;
 
         /// <summary>
@@ -46,10 +45,8 @@ namespace Serilog.Sinks.AzureTableStorage
         /// <param name="additionalRowKeyPostfix">Additional postfix string that will be appended to row keys</param>
         /// <param name="keyGenerator">Generates the PartitionKey and the RowKey</param>
         /// <param name="specificProperties">Specific properties to be added to the Table Storage</param>
-        /// <param name="onlySpecificProperties">Only configure the specific properties specified; otherwise, all properties provided 
-        /// in the message templates will be created</param>
         /// <returns>Logger configuration, allowing configuration to continue.</returns>
-        public AzureTableStorageWithPropertiesSink(CloudStorageAccount storageAccount, IFormatProvider formatProvider, string storageTableName = null, string additionalRowKeyPostfix = null, IKeyGenerator keyGenerator = null, string[] specificProperties = null, bool onlySpecificProperties = false)
+        public AzureTableStorageWithPropertiesSink(CloudStorageAccount storageAccount, IFormatProvider formatProvider, string storageTableName = null, string additionalRowKeyPostfix = null, IKeyGenerator keyGenerator = null, string[] specificProperties = null)
         {
             var tableClient = storageAccount.CreateCloudTableClient();
 
@@ -64,7 +61,6 @@ namespace Serilog.Sinks.AzureTableStorage
             _formatProvider = formatProvider;
             _additionalRowKeyPostfix = additionalRowKeyPostfix;
             _specificProperties = specificProperties;
-            _onlySpecificProperties = onlySpecificProperties;
             _keyGenerator = keyGenerator ?? new PropertiesKeyGenerator();
         }
 
@@ -74,7 +70,7 @@ namespace Serilog.Sinks.AzureTableStorage
         /// <param name="logEvent">The log event to write.</param>
         public void Emit(LogEvent logEvent)
         {
-            var op = TableOperation.Insert(AzureTableStorageEntityFactory.CreateEntityWithProperties(logEvent, _formatProvider, _additionalRowKeyPostfix, _keyGenerator, _specificProperties, _onlySpecificProperties));
+            var op = TableOperation.Insert(AzureTableStorageEntityFactory.CreateEntityWithProperties(logEvent, _formatProvider, _additionalRowKeyPostfix, _keyGenerator, _specificProperties));
 
             _table.ExecuteAsync(op).SyncContextSafeWait(_waitTimeoutMilliseconds);
         }

--- a/src/Serilog.Sinks.AzureTableStorage/Sinks/AzureTableStorageWithProperties/AzureTableStorageWithPropertiesSink.cs
+++ b/src/Serilog.Sinks.AzureTableStorage/Sinks/AzureTableStorageWithProperties/AzureTableStorageWithPropertiesSink.cs
@@ -33,7 +33,7 @@ namespace Serilog.Sinks.AzureTableStorage
         private readonly IFormatProvider _formatProvider;
         private readonly CloudTable _table;
         private readonly string _additionalRowKeyPostfix;
-        private readonly string[] _specificProperties;
+        private readonly string[] _propertyColumns;
         private readonly IKeyGenerator _keyGenerator;
 
         /// <summary>
@@ -44,9 +44,8 @@ namespace Serilog.Sinks.AzureTableStorage
         /// <param name="storageTableName">Table name that log entries will be written to. Note: Optional, setting this may impact performance</param>
         /// <param name="additionalRowKeyPostfix">Additional postfix string that will be appended to row keys</param>
         /// <param name="keyGenerator">Generates the PartitionKey and the RowKey</param>
-        /// <param name="specificProperties">Specific properties to be added to the Table Storage</param>
-        /// <returns>Logger configuration, allowing configuration to continue.</returns>
-        public AzureTableStorageWithPropertiesSink(CloudStorageAccount storageAccount, IFormatProvider formatProvider, string storageTableName = null, string additionalRowKeyPostfix = null, IKeyGenerator keyGenerator = null, string[] specificProperties = null)
+        /// <param name="propertyColumns">Specific properties to be written to columns. By default, all properties will be written to columns.</param>
+        public AzureTableStorageWithPropertiesSink(CloudStorageAccount storageAccount, IFormatProvider formatProvider, string storageTableName = null, string additionalRowKeyPostfix = null, IKeyGenerator keyGenerator = null, string[] propertyColumns = null)
         {
             var tableClient = storageAccount.CreateCloudTableClient();
 
@@ -60,7 +59,7 @@ namespace Serilog.Sinks.AzureTableStorage
 
             _formatProvider = formatProvider;
             _additionalRowKeyPostfix = additionalRowKeyPostfix;
-            _specificProperties = specificProperties;
+            _propertyColumns = propertyColumns;
             _keyGenerator = keyGenerator ?? new PropertiesKeyGenerator();
         }
 
@@ -70,7 +69,7 @@ namespace Serilog.Sinks.AzureTableStorage
         /// <param name="logEvent">The log event to write.</param>
         public void Emit(LogEvent logEvent)
         {
-            var op = TableOperation.Insert(AzureTableStorageEntityFactory.CreateEntityWithProperties(logEvent, _formatProvider, _additionalRowKeyPostfix, _keyGenerator, _specificProperties));
+            var op = TableOperation.Insert(AzureTableStorageEntityFactory.CreateEntityWithProperties(logEvent, _formatProvider, _additionalRowKeyPostfix, _keyGenerator, _propertyColumns));
 
             _table.ExecuteAsync(op).SyncContextSafeWait(_waitTimeoutMilliseconds);
         }

--- a/test/Serilog.Sinks.AzureTableStorageWithProperties.Tests/AzureTableStorageEntityFactoryTests.cs
+++ b/test/Serilog.Sinks.AzureTableStorageWithProperties.Tests/AzureTableStorageEntityFactoryTests.cs
@@ -239,5 +239,49 @@ namespace Serilog.Sinks.AzureTableStorage.Tests
             Assert.Equal(252, entity.Properties.Count);
             Assert.Contains("AggregatedProperties", entity.Properties.Keys.ToList());
         }
+
+        [Fact]
+        public void CreateEntityWithAdditionalPropertiesOnlyShouldNotAddUnspecifiedProperties()
+        {
+            const string messageTemplate = "{IncludedProperty} {AdditionalProperty}";
+            const string includedPropertyValue = "included value";
+            const string excludedPropertyValue = "excluded value";
+            var includedProperties = new[] {"IncludedProperty"};
+
+            var properties = new List<LogEventProperty> {
+                new LogEventProperty("IncludedProperty", new ScalarValue(includedPropertyValue)),
+                new LogEventProperty("AdditionalProperty", new ScalarValue(excludedPropertyValue))
+            };
+
+            var template = new MessageTemplateParser().Parse(messageTemplate);
+            var logEvent = new LogEvent(DateTime.Now, LogEventLevel.Information, null, template, properties);
+
+            var entity = AzureTableStorageEntityFactory.CreateEntityWithProperties(logEvent, null, null, new PropertiesKeyGenerator(), includedProperties, true);
+
+            Assert.True(entity.Properties.ContainsKey("IncludedProperty"));
+            Assert.False(entity.Properties.ContainsKey("AdditionalProperty"));
+        }
+
+        [Fact]
+        public void CreateEntityWithAdditionalPropertiesShouldAddUnspecifiedProperties()
+        {
+            const string messageTemplate = "{IncludedProperty} {AdditionalProperty}";
+            const string includedPropertyValue = "included value";
+            const string excludedPropertyValue = "excluded value";
+            var includedProperties = new[] { "IncludedProperty" };
+
+            var properties = new List<LogEventProperty> {
+                new LogEventProperty("IncludedProperty", new ScalarValue(includedPropertyValue)),
+                new LogEventProperty("AdditionalProperty", new ScalarValue(excludedPropertyValue))
+            };
+
+            var template = new MessageTemplateParser().Parse(messageTemplate);
+            var logEvent = new LogEvent(DateTime.Now, LogEventLevel.Information, null, template, properties);
+
+            var entity = AzureTableStorageEntityFactory.CreateEntityWithProperties(logEvent, null, null, new PropertiesKeyGenerator(), includedProperties);
+
+            Assert.True(entity.Properties.ContainsKey("IncludedProperty"));
+            Assert.True(entity.Properties.ContainsKey("AdditionalProperty"));
+        }
     }
 }

--- a/test/Serilog.Sinks.AzureTableStorageWithProperties.Tests/AzureTableStorageEntityFactoryTests.cs
+++ b/test/Serilog.Sinks.AzureTableStorageWithProperties.Tests/AzureTableStorageEntityFactoryTests.cs
@@ -256,32 +256,10 @@ namespace Serilog.Sinks.AzureTableStorage.Tests
             var template = new MessageTemplateParser().Parse(messageTemplate);
             var logEvent = new LogEvent(DateTime.Now, LogEventLevel.Information, null, template, properties);
 
-            var entity = AzureTableStorageEntityFactory.CreateEntityWithProperties(logEvent, null, null, new PropertiesKeyGenerator(), includedProperties, true);
-
-            Assert.True(entity.Properties.ContainsKey("IncludedProperty"));
-            Assert.False(entity.Properties.ContainsKey("AdditionalProperty"));
-        }
-
-        [Fact]
-        public void CreateEntityWithAdditionalPropertiesShouldAddUnspecifiedProperties()
-        {
-            const string messageTemplate = "{IncludedProperty} {AdditionalProperty}";
-            const string includedPropertyValue = "included value";
-            const string excludedPropertyValue = "excluded value";
-            var includedProperties = new[] { "IncludedProperty" };
-
-            var properties = new List<LogEventProperty> {
-                new LogEventProperty("IncludedProperty", new ScalarValue(includedPropertyValue)),
-                new LogEventProperty("AdditionalProperty", new ScalarValue(excludedPropertyValue))
-            };
-
-            var template = new MessageTemplateParser().Parse(messageTemplate);
-            var logEvent = new LogEvent(DateTime.Now, LogEventLevel.Information, null, template, properties);
-
             var entity = AzureTableStorageEntityFactory.CreateEntityWithProperties(logEvent, null, null, new PropertiesKeyGenerator(), includedProperties);
 
             Assert.True(entity.Properties.ContainsKey("IncludedProperty"));
-            Assert.True(entity.Properties.ContainsKey("AdditionalProperty"));
+            Assert.False(entity.Properties.ContainsKey("AdditionalProperty"));
         }
     }
 }


### PR DESCRIPTION
I have added the ability to declare specific properties to write to the Azure Table Storage when configuring the Azure Table Storage Sink. I've taken the very simple approach of creating a string[] parameter to pass through the specific property names that are to be created by the sink.

**A few things to note:**
1.) By providing the specificProperties, any properties in the  LogEvent that are not included in the specificProperties will only be added to the Data column; no additional columns will be added to the table storage
2.) If specificProperties is left undefined (or null), the current functionality works as expected. 

**Assumptions:**
If you specify the "specificProperties", then other unspecified properties in the LogEvent will not be created. 
Reasoning: If the intended functionality was to ensure that "specificProperties" were added to the log table, all that is needed is to add them to the messageTemplate and use the AzureTableStorageWithPropertiesSink as intended. 

**Unit Tests:**
I've also added a unit tests to ensure that any unspecified properties will not be added to the datatable

**Disclaimer**
I am a very huge advocate for open source, however, this is my first attempt at a contribution. Please feel free to contact me with any helpful advice and any other questions about this pull-request.

Thanks!