### PR TITLE
Added ability to provide own TextFormatter for formatting the Data field

### DIFF
--- a/src/Serilog.Sinks.AzureTableStorage/LoggerConfigurationAzureTableStorageExtensions.cs
+++ b/src/Serilog.Sinks.AzureTableStorage/LoggerConfigurationAzureTableStorageExtensions.cs
@@ -17,6 +17,7 @@ using Microsoft.WindowsAzure.Storage;
 using Serilog.Configuration;
 using Serilog.Core;
 using Serilog.Events;
+using Serilog.Formatting;
 using Serilog.Sinks.AzureTableStorage;
 using Serilog.Sinks.AzureTableStorage.KeyGenerator;
 using Serilog.Sinks.AzureTableStorage.Sinks;
@@ -52,6 +53,7 @@ namespace Serilog
         /// <param name="batchPostingLimit">The maximum number of events to post in a single batch.</param>
         /// <param name="period">The time to wait between checking for event batches.</param>
         /// <param name="keyGenerator">The key generator used to create the PartitionKey and the RowKey for each log entry</param>
+        /// <param name="textFormatter">The text formatter to format the data</param>
         /// <returns>Logger configuration, allowing configuration to continue.</returns>
         /// <exception cref="ArgumentNullException">A required parameter is null.</exception>
         public static LoggerConfiguration AzureTableStorage(
@@ -63,7 +65,8 @@ namespace Serilog
             bool writeInBatches = false,
             TimeSpan? period = null,
             int? batchPostingLimit = null,
-            IKeyGenerator keyGenerator = null)
+            IKeyGenerator keyGenerator = null,
+            ITextFormatter textFormatter = null)
         {
             if (loggerConfiguration == null) throw new ArgumentNullException("loggerConfiguration");
             if (storageAccount == null) throw new ArgumentNullException("storageAccount");
@@ -73,8 +76,8 @@ namespace Serilog
             try
             {
                 sink = writeInBatches ?
-                    (ILogEventSink)new AzureBatchingTableStorageSink(storageAccount, formatProvider, batchPostingLimit ?? DefaultBatchPostingLimit, period ?? DefaultPeriod, storageTableName, keyGenerator) :
-                    new AzureTableStorageSink(storageAccount, formatProvider, storageTableName, keyGenerator);
+                    (ILogEventSink)new AzureBatchingTableStorageSink(storageAccount, formatProvider, batchPostingLimit ?? DefaultBatchPostingLimit, period ?? DefaultPeriod, storageTableName, keyGenerator, textFormatter) :
+                    new AzureTableStorageSink(storageAccount, formatProvider, storageTableName, keyGenerator, textFormatter);
             }
             catch (Exception ex)
             {
@@ -98,7 +101,7 @@ namespace Serilog
         /// <param name="batchPostingLimit">The maximum number of events to post in a single batch.</param>
         /// <param name="period">The time to wait between checking for event batches.</param>
         /// <param name="keyGenerator">The key generator used to create the PartitionKey and the RowKey for each log entry</param>
-        /// <param name="propagateExceptions">Whether connection string issues should throw an exception; disabled by default.</param>
+        /// <param name="textFormatter">The text formatter to format the data</param>
         /// <returns>Logger configuration, allowing configuration to continue.</returns>
         /// <exception cref="ArgumentNullException">A required parameter is null.</exception>
         public static LoggerConfiguration AzureTableStorage(
@@ -110,7 +113,8 @@ namespace Serilog
             bool writeInBatches = false,
             TimeSpan? period = null,
             int? batchPostingLimit = null,
-            IKeyGenerator keyGenerator = null)
+            IKeyGenerator keyGenerator = null,
+            ITextFormatter textFormatter = null)
         {
             if (loggerConfiguration == null) throw new ArgumentNullException("loggerConfiguration");
             if (String.IsNullOrEmpty(connectionString)) throw new ArgumentNullException("connectionString");
@@ -118,7 +122,7 @@ namespace Serilog
             try
             {
                 var storageAccount = CloudStorageAccount.Parse(connectionString);
-                return AzureTableStorage(loggerConfiguration, storageAccount, restrictedToMinimumLevel, formatProvider, storageTableName, writeInBatches, period, batchPostingLimit, keyGenerator);
+                return AzureTableStorage(loggerConfiguration, storageAccount, restrictedToMinimumLevel, formatProvider, storageTableName, writeInBatches, period, batchPostingLimit, keyGenerator, textFormatter);
             }
             catch (Exception ex)
             {

--- a/src/Serilog.Sinks.AzureTableStorage/Sinks/AzureTableStorage/LogEventEntity.cs
+++ b/src/Serilog.Sinks.AzureTableStorage/Sinks/AzureTableStorage/LogEventEntity.cs
@@ -17,6 +17,7 @@ using System.IO;
 using System.Text.RegularExpressions;
 using Microsoft.WindowsAzure.Storage.Table;
 using Serilog.Events;
+using Serilog.Formatting;
 using Serilog.Formatting.Json;
 
 namespace Serilog.Sinks.AzureTableStorage
@@ -41,11 +42,13 @@ namespace Serilog.Sinks.AzureTableStorage
         /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
         /// <param name="partitionKey">partition key to store</param>
         /// <param name="rowKey">row key to store</param>
+        /// <param name="textFormatter">The text formatter to format the data</param>
         public LogEventEntity(
             LogEvent log,
             IFormatProvider formatProvider,
             string partitionKey,
-            string rowKey)
+            string rowKey,
+            ITextFormatter textFormatter)
         {
             Timestamp = log.Timestamp.ToUniversalTime().DateTime;
             PartitionKey = partitionKey;
@@ -55,7 +58,11 @@ namespace Serilog.Sinks.AzureTableStorage
             Exception = log.Exception?.ToString();
             RenderedMessage = log.RenderMessage(formatProvider);
             var s = new StringWriter();
-            new JsonFormatter(closingDelimiter: "", formatProvider: formatProvider).Format(log, s);
+            if (textFormatter == null)
+            {
+                textFormatter = new JsonFormatter(closingDelimiter: "", formatProvider: formatProvider);
+            }
+            textFormatter.Format(log, s);
             Data = s.ToString();
         }
 
@@ -83,7 +90,7 @@ namespace Serilog.Sinks.AzureTableStorage
         /// </summary>
         public string RenderedMessage { get; set; }
         /// <summary>
-        /// A JSON-serialised representation of the data attached to the log message.
+        /// A text-serialised representation of the data attached to the log message.
         /// </summary>
         public string Data { get; set; }
     }


### PR DESCRIPTION
I provided an optional ITextFormatter parameter into the AzureTableStorage sink that allows a system to provide their own customer formatter if they want more influence over how the Data field is serialized in Azure. If they do not provide this parameter, it falls back to the original/default behavior as before.

Let me know if you have any questions. Thanks!