### PR TITLE
Added parameter rollOnDateChange to AzureTableStorageSink

### DIFF
--- a/src/Serilog.Sinks.AzureTableStorage/LoggerConfigurationAzureTableStorageExtensions.cs
+++ b/src/Serilog.Sinks.AzureTableStorage/LoggerConfigurationAzureTableStorageExtensions.cs
@@ -53,6 +53,7 @@ namespace Serilog
         /// <param name="period">The time to wait between checking for event batches.</param>
         /// <param name="keyGenerator">The key generator used to create the PartitionKey and the RowKey for each log entry</param>
         /// <param name="bypassTableCreationValidation">Bypass the exception in case the table creation fails.</param>
+        /// <param name="rollOnDateChange">Roll on to create new table on date change.</param>
         /// <returns>Logger configuration, allowing configuration to continue.</returns>
         /// <exception cref="ArgumentNullException">A required parameter is null.</exception>
         public static LoggerConfiguration AzureTableStorage(
@@ -65,7 +66,8 @@ namespace Serilog
             TimeSpan? period = null,
             int? batchPostingLimit = null,
             IKeyGenerator keyGenerator = null,
-            bool bypassTableCreationValidation = false)
+            bool bypassTableCreationValidation = false,
+            bool rollOnDateChange = false)
         {
             if (loggerConfiguration == null) throw new ArgumentNullException(nameof(loggerConfiguration));
             if (storageAccount == null) throw new ArgumentNullException(nameof(storageAccount));
@@ -75,8 +77,8 @@ namespace Serilog
             try
             {
                 sink = writeInBatches ?
-                    (ILogEventSink)new AzureBatchingTableStorageSink(storageAccount, formatProvider, batchPostingLimit ?? DefaultBatchPostingLimit, period ?? DefaultPeriod, storageTableName, keyGenerator, bypassTableCreationValidation) :
-                    new AzureTableStorageSink(storageAccount, formatProvider, storageTableName, keyGenerator, bypassTableCreationValidation);
+                    (ILogEventSink)new AzureBatchingTableStorageSink(storageAccount, formatProvider, batchPostingLimit ?? DefaultBatchPostingLimit, period ?? DefaultPeriod, storageTableName, keyGenerator, bypassTableCreationValidation, rollOnDateChange) :
+                    new AzureTableStorageSink(storageAccount, formatProvider, storageTableName, keyGenerator, bypassTableCreationValidation, rollOnDateChange);
             }
             catch (Exception ex)
             {
@@ -102,6 +104,7 @@ namespace Serilog
         /// <param name="period">The time to wait between checking for event batches.</param>
         /// <param name="keyGenerator">The key generator used to create the PartitionKey and the RowKey for each log entry</param>
         /// <param name="bypassTableCreationValidation">Bypass the exception in case the table creation fails.</param>
+        /// <param name="rollOnDateChange">Roll on to create new table on date change.</param>
         /// <returns>Logger configuration, allowing configuration to continue.</returns>
         /// <exception cref="ArgumentNullException">A required parameter is null.</exception>
         public static LoggerConfiguration AzureTableStorage(
@@ -114,7 +117,8 @@ namespace Serilog
             TimeSpan? period = null,
             int? batchPostingLimit = null,
             IKeyGenerator keyGenerator = null,
-            bool bypassTableCreationValidation = false)
+            bool bypassTableCreationValidation = false,
+            bool rollOnDateChange = false)
         {
             if (loggerConfiguration == null) throw new ArgumentNullException(nameof(loggerConfiguration));
             if (string.IsNullOrEmpty(connectionString)) throw new ArgumentNullException(nameof(connectionString));
@@ -122,7 +126,7 @@ namespace Serilog
             try
             {
                 var storageAccount = CloudStorageAccount.Parse(connectionString);
-                return AzureTableStorage(loggerConfiguration, storageAccount, restrictedToMinimumLevel, formatProvider, storageTableName, writeInBatches, period, batchPostingLimit, keyGenerator, bypassTableCreationValidation);
+                return AzureTableStorage(loggerConfiguration, storageAccount, restrictedToMinimumLevel, formatProvider, storageTableName, writeInBatches, period, batchPostingLimit, keyGenerator, bypassTableCreationValidation, rollOnDateChange);
             }
             catch (Exception ex)
             {
@@ -150,6 +154,7 @@ namespace Serilog
         /// <param name="period">The time to wait between checking for event batches.</param>
         /// <param name="keyGenerator">The key generator used to create the PartitionKey and the RowKey for each log entry</param>
         /// <param name="bypassTableCreationValidation">Bypass the exception in case the table creation fails.</param>
+        /// <param name="rollOnDateChange">Roll on to create new table on date change.</param>
         /// <returns>Logger configuration, allowing configuration to continue.</returns>
         /// <exception cref="ArgumentNullException">A required parameter is null.</exception>
         public static LoggerConfiguration AzureTableStorage(
@@ -163,7 +168,8 @@ namespace Serilog
             bool writeInBatches = false,
             TimeSpan? period = null,
             int? batchPostingLimit = null,
-            IKeyGenerator keyGenerator = null)
+            IKeyGenerator keyGenerator = null,
+            bool rollOnDateChange = false)
         {
             if (loggerConfiguration == null) throw new ArgumentNullException(nameof(loggerConfiguration));
             if (string.IsNullOrWhiteSpace(accountName)) throw new ArgumentNullException(nameof(accountName));
@@ -183,7 +189,7 @@ namespace Serilog
                 }
 
                 // We set bypassTableCreationValidation to true explicitly here as the the SAS URL might not have enough permissions to query if the table exists.
-                return AzureTableStorage(loggerConfiguration, storageAccount, restrictedToMinimumLevel, formatProvider, storageTableName, writeInBatches, period, batchPostingLimit, keyGenerator, true);
+                return AzureTableStorage(loggerConfiguration, storageAccount, restrictedToMinimumLevel, formatProvider, storageTableName, writeInBatches, period, batchPostingLimit, keyGenerator, true, rollOnDateChange);
             }
             catch (Exception ex)
             {

--- a/src/Serilog.Sinks.AzureTableStorage/LoggerConfigurationAzureTableStorageWithPropertiesExtensions.cs
+++ b/src/Serilog.Sinks.AzureTableStorage/LoggerConfigurationAzureTableStorageWithPropertiesExtensions.cs
@@ -55,6 +55,7 @@ namespace Serilog
         /// <param name="keyGenerator">Generates the PartitionKey and the RowKey</param>
         /// <param name="propertyColumns">Specific properties to be written to columns. By default, all properties will be written to columns.</param>
         /// <param name="bypassTableCreationValidation">Bypass the exception in case the table creation fails.</param>
+        /// <param name="rollOnDateChange">Roll on to create new table on date change.</param>
         /// <returns>Logger configuration, allowing configuration to continue.</returns>
         /// <exception cref="ArgumentNullException">A required parameter is null.</exception>
         public static LoggerConfiguration AzureTableStorageWithProperties(
@@ -69,7 +70,8 @@ namespace Serilog
             string additionalRowKeyPostfix = null,
             IKeyGenerator keyGenerator = null,
             string[] propertyColumns = null,
-            bool bypassTableCreationValidation = false)
+            bool bypassTableCreationValidation = false,
+            bool rollOnDateChange = false)
         {
             if (loggerConfiguration == null) throw new ArgumentNullException(nameof(loggerConfiguration));
             if (storageAccount == null) throw new ArgumentNullException(nameof(storageAccount));
@@ -80,8 +82,8 @@ namespace Serilog
             {
                 sink = writeInBatches
                     ? (ILogEventSink)
-                    new AzureBatchingTableStorageWithPropertiesSink(storageAccount, formatProvider, batchPostingLimit ?? DefaultBatchPostingLimit, period ?? DefaultPeriod, storageTableName, additionalRowKeyPostfix, keyGenerator, propertyColumns, bypassTableCreationValidation)
-                    : new AzureTableStorageWithPropertiesSink(storageAccount, formatProvider, storageTableName, additionalRowKeyPostfix, keyGenerator, propertyColumns, bypassTableCreationValidation);
+                    new AzureBatchingTableStorageWithPropertiesSink(storageAccount, formatProvider, batchPostingLimit ?? DefaultBatchPostingLimit, period ?? DefaultPeriod, storageTableName, additionalRowKeyPostfix, keyGenerator, propertyColumns, bypassTableCreationValidation, rollOnDateChange)
+                    : new AzureTableStorageWithPropertiesSink(storageAccount, formatProvider, storageTableName, additionalRowKeyPostfix, keyGenerator, propertyColumns, bypassTableCreationValidation, rollOnDateChange);
             }
             catch (Exception ex)
             {
@@ -109,6 +111,7 @@ namespace Serilog
         /// <param name="keyGenerator">Generates the PartitionKey and the RowKey</param>
         /// <param name="propertyColumns">Specific properties to be written to columns. By default, all properties will be written to columns.</param>
         /// <param name="bypassTableCreationValidation">Bypass the exception in case the table creation fails.</param>
+        /// <param name="rollOnDateChange">Roll on to create new table on date change.</param>
         /// <returns>Logger configuration, allowing configuration to continue.</returns>
         /// <exception cref="ArgumentNullException">A required parameter is null.</exception>
         public static LoggerConfiguration AzureTableStorageWithProperties(
@@ -123,7 +126,8 @@ namespace Serilog
             string additionalRowKeyPostfix = null,
             IKeyGenerator keyGenerator = null,
             string[] propertyColumns = null,
-            bool bypassTableCreationValidation = false)
+            bool bypassTableCreationValidation = false,
+            bool rollOnDateChange = false)
         {
             if (loggerConfiguration == null) throw new ArgumentNullException(nameof(loggerConfiguration));
             if (String.IsNullOrEmpty(connectionString)) throw new ArgumentNullException(nameof(connectionString));
@@ -131,7 +135,7 @@ namespace Serilog
             try
             {
                 var storageAccount = CloudStorageAccount.Parse(connectionString);
-                return AzureTableStorageWithProperties(loggerConfiguration, storageAccount, restrictedToMinimumLevel, formatProvider, storageTableName, writeInBatches, period, batchPostingLimit, additionalRowKeyPostfix, keyGenerator, propertyColumns, bypassTableCreationValidation);
+                return AzureTableStorageWithProperties(loggerConfiguration, storageAccount, restrictedToMinimumLevel, formatProvider, storageTableName, writeInBatches, period, batchPostingLimit, additionalRowKeyPostfix, keyGenerator, propertyColumns, bypassTableCreationValidation, rollOnDateChange);
             }
             catch (Exception ex)
             {
@@ -160,6 +164,7 @@ namespace Serilog
         /// <param name="additionalRowKeyPostfix">Additional postfix string that will be appended to row keys</param>
         /// <param name="keyGenerator">Generates the PartitionKey and the RowKey</param>
         /// <param name="propertyColumns">Specific properties to be written to columns. By default, all properties will be written to columns.</param>
+        /// <param name="rollOnDateChange">Roll on to create new table on date change.</param>
         /// <returns>Logger configuration, allowing configuration to continue.</returns>
         /// <exception cref="ArgumentNullException">A required parameter is null.</exception>
         /// /// <exception cref="ArgumentException">A required parameter is empty.</exception>
@@ -176,7 +181,8 @@ namespace Serilog
             int? batchPostingLimit = null,
             string additionalRowKeyPostfix = null,
             IKeyGenerator keyGenerator = null,
-            string[] propertyColumns = null)
+            string[] propertyColumns = null,
+            bool rollOnDateChange = false)
         {
             if (loggerConfiguration == null) throw new ArgumentNullException(nameof(loggerConfiguration));
             if (string.IsNullOrWhiteSpace(accountName)) throw new ArgumentException(nameof(accountName));
@@ -196,7 +202,7 @@ namespace Serilog
                 }
 
                 // We set bypassTableCreationValidation to true explicitly here as the the SAS URL might not have enough permissions to query if the table exists.
-                return AzureTableStorageWithProperties(loggerConfiguration, storageAccount, restrictedToMinimumLevel, formatProvider, storageTableName, writeInBatches, period, batchPostingLimit, additionalRowKeyPostfix, keyGenerator, propertyColumns, true);
+                return AzureTableStorageWithProperties(loggerConfiguration, storageAccount, restrictedToMinimumLevel, formatProvider, storageTableName, writeInBatches, period, batchPostingLimit, additionalRowKeyPostfix, keyGenerator, propertyColumns, true, rollOnDateChange);
             }
             catch (Exception ex)
             {

--- a/src/Serilog.Sinks.AzureTableStorage/Serilog.Sinks.AzureTableStorage.csproj
+++ b/src/Serilog.Sinks.AzureTableStorage/Serilog.Sinks.AzureTableStorage.csproj
@@ -25,4 +25,7 @@
     <PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="2.1.1" />
     <PackageReference Include="WindowsAzure.Storage" Version="9.1.0" />
   </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Sinks\AzureTableProvider\" />
+  </ItemGroup>
 </Project>

--- a/src/Serilog.Sinks.AzureTableStorage/Sinks/AzureTableProvider/DefaultCloudTableProvider.cs
+++ b/src/Serilog.Sinks.AzureTableStorage/Sinks/AzureTableProvider/DefaultCloudTableProvider.cs
@@ -1,0 +1,63 @@
+﻿// Copyright 2014 Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Threading;
+using Microsoft.WindowsAzure.Storage;
+using Microsoft.WindowsAzure.Storage.Table;
+
+namespace Serilog.Sinks.AzureTableStorage.AzureTableProvider
+{
+    public class DefaultCloudTableProvider : ICloudTableProvider
+    {
+        private readonly int _waitTimeoutMilliseconds = Timeout.Infinite;
+        private readonly CloudTableClient _cloudTableClient;
+        private readonly string _storageTableName;
+        private readonly bool _bypassTableCreationValidation;
+        private CloudTable _cloudTable;
+
+        public DefaultCloudTableProvider(CloudStorageAccount storageAccount,
+                                         string storageTableName,
+                                         bool bypassTableCreationValidation)
+        {
+            _cloudTableClient = storageAccount.CreateCloudTableClient();
+            _storageTableName = storageTableName;
+            _bypassTableCreationValidation = bypassTableCreationValidation;
+        }
+
+        public CloudTable GetCloudTable()
+        {
+            if (_cloudTable == null)
+            {
+                _cloudTable = _cloudTableClient.GetTableReference(_storageTableName);
+
+                // In some cases (e.g.: SAS URI), we might not have enough permissions to create the table if
+                // it does not already exists. So, if we are in that case, we ignore the error as per bypassTableCreationValidation.
+                try
+                {
+                    _cloudTable.CreateIfNotExistsAsync().SyncContextSafeWait(_waitTimeoutMilliseconds);
+                }
+                catch (Exception ex)
+                {
+                    Debugging.SelfLog.WriteLine($"Failed to create table: {ex}");
+                    if (!_bypassTableCreationValidation)
+                    {
+                        throw;
+                    }
+                }
+            }
+            return _cloudTable;
+        }
+    }
+}

--- a/src/Serilog.Sinks.AzureTableStorage/Sinks/AzureTableProvider/ICloudTableProvider.cs
+++ b/src/Serilog.Sinks.AzureTableStorage/Sinks/AzureTableProvider/ICloudTableProvider.cs
@@ -1,0 +1,23 @@
+﻿// Copyright 2014 Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Microsoft.WindowsAzure.Storage.Table;
+
+namespace Serilog.Sinks.AzureTableStorage.AzureTableProvider
+{
+    public interface ICloudTableProvider
+    {
+        CloudTable GetCloudTable();
+    }
+}

--- a/src/Serilog.Sinks.AzureTableStorage/Sinks/AzureTableProvider/RollingCloudTableProvider.cs
+++ b/src/Serilog.Sinks.AzureTableStorage/Sinks/AzureTableProvider/RollingCloudTableProvider.cs
@@ -1,0 +1,66 @@
+﻿// Copyright 2014 Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Threading;
+using Microsoft.WindowsAzure.Storage;
+using Microsoft.WindowsAzure.Storage.Table;
+
+namespace Serilog.Sinks.AzureTableStorage.AzureTableProvider
+{
+    public class RollingCloudTableProvider : ICloudTableProvider
+    {
+        private readonly int _waitTimeoutMilliseconds = Timeout.Infinite;
+        private readonly CloudTableClient _cloudTableClient;
+        private readonly string _storageTableNamePrefix;
+        private readonly bool _bypassTableCreationValidation;
+        private CloudTable _cloudTable;
+
+        private static string Ticks => DateTime.Today.Ticks.ToString();
+
+        public RollingCloudTableProvider(CloudStorageAccount storageAccount,
+                                         string storageTableNamePrefix,
+                                         bool bypassTableCreationValidation)
+        {
+            _cloudTableClient = storageAccount.CreateCloudTableClient();
+            _storageTableNamePrefix = storageTableNamePrefix;
+            _bypassTableCreationValidation = bypassTableCreationValidation;
+        }
+
+        public CloudTable GetCloudTable()
+        {
+            if (_cloudTable == null || _cloudTable.Name.Remove(0, _storageTableNamePrefix.Length) == Ticks)
+            {
+                var storageTableName = $"{_storageTableNamePrefix}{Ticks}";
+                _cloudTable = _cloudTableClient.GetTableReference(storageTableName);
+
+                // In some cases (e.g.: SAS URI), we might not have enough permissions to create the table if
+                // it does not already exists. So, if we are in that case, we ignore the error as per bypassTableCreationValidation.
+                try
+                {
+                    _cloudTable.CreateIfNotExistsAsync().SyncContextSafeWait(_waitTimeoutMilliseconds);
+                }
+                catch (Exception ex)
+                {
+                    Debugging.SelfLog.WriteLine($"Failed to create table: {ex}");
+                    if (!_bypassTableCreationValidation)
+                    {
+                        throw;
+                    }
+                }
+            }
+            return _cloudTable;
+        }
+    }
+}

--- a/src/Serilog.Sinks.AzureTableStorage/Sinks/AzureTableStorage/AzureBatchingTableStorageSink.cs
+++ b/src/Serilog.Sinks.AzureTableStorage/Sinks/AzureTableStorage/AzureBatchingTableStorageSink.cs
@@ -19,6 +19,7 @@ using System.Threading.Tasks;
 using Microsoft.WindowsAzure.Storage;
 using Microsoft.WindowsAzure.Storage.Table;
 using Serilog.Events;
+using Serilog.Sinks.AzureTableStorage.AzureTableProvider;
 using Serilog.Sinks.AzureTableStorage.KeyGenerator;
 using Serilog.Sinks.PeriodicBatching;
 
@@ -32,7 +33,7 @@ namespace Serilog.Sinks.AzureTableStorage
         private readonly int _waitTimeoutMilliseconds = Timeout.Infinite;
         private readonly IFormatProvider _formatProvider;
         private readonly IKeyGenerator _keyGenerator;
-        private readonly CloudTable _table;
+        private readonly ICloudTableProvider _cloudTableProvider;
 
         /// <summary>
         /// Construct a sink that saves logs to the specified storage account.
@@ -42,13 +43,15 @@ namespace Serilog.Sinks.AzureTableStorage
         /// <param name="batchSizeLimit"></param>
         /// <param name="period"></param>
         /// <param name="storageTableName">Table name that log entries will be written to. Note: Optional, setting this may impact performance</param>
+        /// <param name="rollOnDateChange">Roll on to create new table on date change.</param>
         public AzureBatchingTableStorageSink(
             CloudStorageAccount storageAccount,
             IFormatProvider formatProvider,
             int batchSizeLimit,
             TimeSpan period,
-            string storageTableName = null)
-            : this(storageAccount, formatProvider, batchSizeLimit, period, storageTableName, new DefaultKeyGenerator())
+            string storageTableName = null,
+            bool rollOnDateChange = false)
+            : this(storageAccount, formatProvider, batchSizeLimit, period, storageTableName, new DefaultKeyGenerator(), rollOnDateChange)
         {
         }
 
@@ -62,6 +65,7 @@ namespace Serilog.Sinks.AzureTableStorage
         /// <param name="storageTableName">Table name that log entries will be written to. Note: Optional, setting this may impact performance</param>
         /// <param name="keyGenerator">generator used for partition keys and row keys</param>
         /// <param name="bypassTableCreationValidation">Bypass the exception in case the table creation fails.</param>
+        /// <param name="rollOnDateChange">Roll on to create new table on date change.</param>
         public AzureBatchingTableStorageSink(
             CloudStorageAccount storageAccount,
             IFormatProvider formatProvider,
@@ -69,7 +73,8 @@ namespace Serilog.Sinks.AzureTableStorage
             TimeSpan period,
             string storageTableName = null,
             IKeyGenerator keyGenerator = null,
-            bool bypassTableCreationValidation = false)
+            bool bypassTableCreationValidation = false,
+            bool rollOnDateChange = false)
             : base(batchSizeLimit, period)
         {
             if (batchSizeLimit < 1 || batchSizeLimit > 100)
@@ -77,30 +82,17 @@ namespace Serilog.Sinks.AzureTableStorage
 
             _formatProvider = formatProvider;
             _keyGenerator = keyGenerator ?? new DefaultKeyGenerator();
-            var tableClient = storageAccount.CreateCloudTableClient();
 
-            if (string.IsNullOrEmpty(storageTableName)) storageTableName = typeof(LogEventEntity).Name;
-
-            _table = tableClient.GetTableReference(storageTableName);
-
-            // In some cases (e.g.: SAS URI), we might not have enough permissions to create the table if
-            // it does not already exists. So, if we are in that case, we ignore the error as per bypassTableCreationValidation.
-            try
+            if (string.IsNullOrEmpty(storageTableName))
             {
-                _table.CreateIfNotExistsAsync().SyncContextSafeWait(_waitTimeoutMilliseconds);
+                storageTableName = typeof(LogEventEntity).Name;
             }
-            catch (Exception ex)
-            {
-                Debugging.SelfLog.WriteLine($"Failed to create table: {ex}");
-                if (!bypassTableCreationValidation)
-                {
-                    throw;
-                }
-            }
+            _cloudTableProvider = rollOnDateChange ? null : new DefaultCloudTableProvider(storageAccount, storageTableName, bypassTableCreationValidation);
         }
 
         protected override async Task EmitBatchAsync(IEnumerable<LogEvent> events)
         {
+            var table = _cloudTableProvider.GetCloudTable();
             TableBatchOperation operation = new TableBatchOperation();
 
             string lastPartitionKey = null;
@@ -114,7 +106,7 @@ namespace Serilog.Sinks.AzureTableStorage
                     lastPartitionKey = partitionKey;
                     if (operation.Count > 0)
                     {
-                        await _table.ExecuteBatchAsync(operation).ConfigureAwait(false);
+                        await table.ExecuteBatchAsync(operation).ConfigureAwait(false);
                         operation = new TableBatchOperation();
                     }
                 }
@@ -128,7 +120,7 @@ namespace Serilog.Sinks.AzureTableStorage
             }
             if (operation.Count > 0)
             {
-                await _table.ExecuteBatchAsync(operation).ConfigureAwait(false);
+                await table.ExecuteBatchAsync(operation).ConfigureAwait(false);
             }
         }
     }

--- a/src/Serilog.Sinks.AzureTableStorage/Sinks/AzureTableStorage/AzureBatchingTableStorageSink.cs
+++ b/src/Serilog.Sinks.AzureTableStorage/Sinks/AzureTableStorage/AzureBatchingTableStorageSink.cs
@@ -87,7 +87,9 @@ namespace Serilog.Sinks.AzureTableStorage
             {
                 storageTableName = typeof(LogEventEntity).Name;
             }
-            _cloudTableProvider = rollOnDateChange ? null : new DefaultCloudTableProvider(storageAccount, storageTableName, bypassTableCreationValidation);
+            _cloudTableProvider = rollOnDateChange
+                ? (ICloudTableProvider)new RollingCloudTableProvider(storageAccount, storageTableName, bypassTableCreationValidation)
+                : new DefaultCloudTableProvider(storageAccount, storageTableName, bypassTableCreationValidation);
         }
 
         protected override async Task EmitBatchAsync(IEnumerable<LogEvent> events)

--- a/src/Serilog.Sinks.AzureTableStorage/Sinks/AzureTableStorage/AzureTableStorageSink.cs
+++ b/src/Serilog.Sinks.AzureTableStorage/Sinks/AzureTableStorage/AzureTableStorageSink.cs
@@ -57,7 +57,9 @@ namespace Serilog.Sinks.AzureTableStorage
             {
                 storageTableName = typeof(LogEventEntity).Name;
             }
-            _cloudTableProvider = rollOnDateChange ? null : new DefaultCloudTableProvider(storageAccount, storageTableName, bypassTableCreationValidation);
+            _cloudTableProvider = rollOnDateChange
+                ? (ICloudTableProvider)new RollingCloudTableProvider(storageAccount, storageTableName, bypassTableCreationValidation)
+                : new DefaultCloudTableProvider(storageAccount, storageTableName, bypassTableCreationValidation);
         }
 
         /// <summary>

--- a/src/Serilog.Sinks.AzureTableStorage/Sinks/AzureTableStorage/AzureTableStorageSink.cs
+++ b/src/Serilog.Sinks.AzureTableStorage/Sinks/AzureTableStorage/AzureTableStorageSink.cs
@@ -18,6 +18,7 @@ using Microsoft.WindowsAzure.Storage;
 using Microsoft.WindowsAzure.Storage.Table;
 using Serilog.Core;
 using Serilog.Events;
+using Serilog.Sinks.AzureTableStorage.AzureTableProvider;
 using Serilog.Sinks.AzureTableStorage.KeyGenerator;
 
 namespace Serilog.Sinks.AzureTableStorage
@@ -30,7 +31,7 @@ namespace Serilog.Sinks.AzureTableStorage
         private readonly int _waitTimeoutMilliseconds = Timeout.Infinite;
         private readonly IFormatProvider _formatProvider;
         private readonly IKeyGenerator _keyGenerator;
-        private readonly CloudTable _table;
+        private readonly ICloudTableProvider _cloudTableProvider;
 
         /// <summary>
         /// Construct a sink that saves logs to the specified storage account.
@@ -40,38 +41,23 @@ namespace Serilog.Sinks.AzureTableStorage
         /// <param name="storageTableName">Table name that log entries will be written to. Note: Optional, setting this may impact performance</param>
         /// <param name="keyGenerator">generator used to generate partition keys and row keys</param>
         /// <param name="bypassTableCreationValidation">Bypass the exception in case the table creation fails.</param>
+        /// <param name="rollOnDateChange">Roll on to create new table on date change.</param>
         public AzureTableStorageSink(
             CloudStorageAccount storageAccount,
             IFormatProvider formatProvider,
             string storageTableName = null,
             IKeyGenerator keyGenerator = null,
-            bool bypassTableCreationValidation = false)
+            bool bypassTableCreationValidation = false,
+            bool rollOnDateChange = false)
         {
             _formatProvider = formatProvider;
             _keyGenerator = keyGenerator ?? new DefaultKeyGenerator();
-            var tableClient = storageAccount.CreateCloudTableClient();
 
             if (string.IsNullOrEmpty(storageTableName))
             {
                 storageTableName = typeof(LogEventEntity).Name;
             }
-
-            _table = tableClient.GetTableReference(storageTableName);
-
-            // In some cases (e.g.: SAS URI), we might not have enough permissions to create the table if
-            // it does not already exists. So, if we are in that case, we ignore the error as per bypassTableCreationValidation.
-            try
-            {
-                _table.CreateIfNotExistsAsync().SyncContextSafeWait(_waitTimeoutMilliseconds);
-            }
-            catch (Exception ex)
-            {
-                Debugging.SelfLog.WriteLine($"Failed to create table: {ex}");
-                if (!bypassTableCreationValidation)
-                {
-                    throw;
-                }
-            }
+            _cloudTableProvider = rollOnDateChange ? null : new DefaultCloudTableProvider(storageAccount, storageTableName, bypassTableCreationValidation);
         }
 
         /// <summary>
@@ -80,6 +66,7 @@ namespace Serilog.Sinks.AzureTableStorage
         /// <param name="logEvent">The log event to write.</param>
         public void Emit(LogEvent logEvent)
         {
+            var table = _cloudTableProvider.GetCloudTable();
             var logEventEntity = new LogEventEntity(
                 logEvent,
                 _formatProvider,
@@ -87,7 +74,7 @@ namespace Serilog.Sinks.AzureTableStorage
                 _keyGenerator.GenerateRowKey(logEvent)
                 );
 
-            _table.ExecuteAsync(TableOperation.Insert(logEventEntity))
+            table.ExecuteAsync(TableOperation.Insert(logEventEntity))
                 .SyncContextSafeWait(_waitTimeoutMilliseconds);
         }
     }

--- a/src/Serilog.Sinks.AzureTableStorage/Sinks/AzureTableStorageWithProperties/AzureBatchingTableStorageWithPropertiesSink.cs
+++ b/src/Serilog.Sinks.AzureTableStorage/Sinks/AzureTableStorageWithProperties/AzureBatchingTableStorageWithPropertiesSink.cs
@@ -71,7 +71,9 @@ namespace Serilog.Sinks.AzureTableStorage
             {
                 storageTableName = "LogEventEntity";
             }
-            _cloudTableProvider = rollOnDateChange ? null : new DefaultCloudTableProvider(storageAccount, storageTableName, bypassTableCreationValidation);
+            _cloudTableProvider = rollOnDateChange
+                ? (ICloudTableProvider)new RollingCloudTableProvider(storageAccount, storageTableName, bypassTableCreationValidation)
+                : new DefaultCloudTableProvider(storageAccount, storageTableName, bypassTableCreationValidation);
 
             _formatProvider = formatProvider;
             _additionalRowKeyPostfix = additionalRowKeyPostfix;

--- a/src/Serilog.Sinks.AzureTableStorage/Sinks/AzureTableStorageWithProperties/AzureBatchingTableStorageWithPropertiesSink.cs
+++ b/src/Serilog.Sinks.AzureTableStorage/Sinks/AzureTableStorageWithProperties/AzureBatchingTableStorageWithPropertiesSink.cs
@@ -19,6 +19,7 @@ using System.Threading.Tasks;
 using Microsoft.WindowsAzure.Storage;
 using Microsoft.WindowsAzure.Storage.Table;
 using Serilog.Events;
+using Serilog.Sinks.AzureTableStorage.AzureTableProvider;
 using Serilog.Sinks.AzureTableStorage.KeyGenerator;
 using Serilog.Sinks.AzureTableStorage.Sinks.KeyGenerator;
 using Serilog.Sinks.PeriodicBatching;
@@ -32,11 +33,11 @@ namespace Serilog.Sinks.AzureTableStorage
     {
         private readonly int _waitTimeoutMilliseconds = Timeout.Infinite;
         private readonly IFormatProvider _formatProvider;
-        private readonly CloudTable _table;
         private readonly string _additionalRowKeyPostfix;
         private readonly string[] _propertyColumns;
         private const int _maxAzureOperationsPerBatch = 100;
         private readonly IKeyGenerator _keyGenerator;
+        private readonly ICloudTableProvider _cloudTableProvider;
 
         /// <summary>
         /// Construct a sink that saves logs to the specified storage account.
@@ -50,6 +51,7 @@ namespace Serilog.Sinks.AzureTableStorage
         /// <param name="keyGenerator">Generates the PartitionKey and the RowKey</param>
         /// <param name="propertyColumns">Specific properties to be written to columns. By default, all properties will be written to columns.</param>
         /// <param name="bypassTableCreationValidation">Bypass the exception in case the table creation fails.</param>
+        /// <param name="rollOnDateChange">Roll on to create new table on date change.</param>
         /// <returns>Logger configuration, allowing configuration to continue.</returns>
         public AzureBatchingTableStorageWithPropertiesSink(CloudStorageAccount storageAccount,
             IFormatProvider formatProvider,
@@ -59,7 +61,8 @@ namespace Serilog.Sinks.AzureTableStorage
             string additionalRowKeyPostfix = null,
             IKeyGenerator keyGenerator = null,
             string[] propertyColumns = null,
-            bool bypassTableCreationValidation = false)
+            bool bypassTableCreationValidation = false,
+            bool rollOnDateChange = false)
             : base(batchSizeLimit, period)
         {
             var tableClient = storageAccount.CreateCloudTableClient();
@@ -68,21 +71,7 @@ namespace Serilog.Sinks.AzureTableStorage
             {
                 storageTableName = "LogEventEntity";
             }
-
-            _table = tableClient.GetTableReference(storageTableName);
-
-            try
-            {
-                _table.CreateIfNotExistsAsync().SyncContextSafeWait(_waitTimeoutMilliseconds);
-            }
-            catch (Exception ex)
-            {
-                Debugging.SelfLog.WriteLine($"Failed to create table: {ex}");
-                if (!bypassTableCreationValidation)
-                {
-                    throw;
-                }
-            }
+            _cloudTableProvider = rollOnDateChange ? null : new DefaultCloudTableProvider(storageAccount, storageTableName, bypassTableCreationValidation);
 
             _formatProvider = formatProvider;
             _additionalRowKeyPostfix = additionalRowKeyPostfix;
@@ -92,6 +81,7 @@ namespace Serilog.Sinks.AzureTableStorage
 
         protected override async Task EmitBatchAsync(IEnumerable<LogEvent> events)
         {
+            var table = _cloudTableProvider.GetCloudTable();
             string lastPartitionKey = null;
             TableBatchOperation operation = null;
             var insertsPerOperation = 0;
@@ -115,7 +105,7 @@ namespace Serilog.Sinks.AzureTableStorage
                     // If there is an operation currently in use, execute it
                     if (operation != null)
                     {
-                        await _table.ExecuteBatchAsync(operation).ConfigureAwait(false);
+                        await table.ExecuteBatchAsync(operation).ConfigureAwait(false);
                     }
 
                     // Create a new batch operation and zero count
@@ -130,7 +120,7 @@ namespace Serilog.Sinks.AzureTableStorage
             }
 
             // Execute last batch
-            await _table.ExecuteBatchAsync(operation).ConfigureAwait(false);
+            await table.ExecuteBatchAsync(operation).ConfigureAwait(false);
         }
     }
 }

--- a/src/Serilog.Sinks.AzureTableStorage/Sinks/AzureTableStorageWithProperties/AzureTableStorageWithPropertiesSink.cs
+++ b/src/Serilog.Sinks.AzureTableStorage/Sinks/AzureTableStorageWithProperties/AzureTableStorageWithPropertiesSink.cs
@@ -62,7 +62,9 @@ namespace Serilog.Sinks.AzureTableStorage
             {
                 storageTableName = "LogEventEntity";
             }
-            _cloudTableProvider = rollOnDateChange ? null : new DefaultCloudTableProvider(storageAccount, storageTableName, bypassTableCreationValidation);
+            _cloudTableProvider = rollOnDateChange
+                ? (ICloudTableProvider)new RollingCloudTableProvider(storageAccount, storageTableName, bypassTableCreationValidation)
+                : new DefaultCloudTableProvider(storageAccount, storageTableName, bypassTableCreationValidation);
 
             _formatProvider = formatProvider;
             _additionalRowKeyPostfix = additionalRowKeyPostfix;

--- a/src/Serilog.Sinks.AzureTableStorage/Sinks/AzureTableStorageWithProperties/AzureTableStorageWithPropertiesSink.cs
+++ b/src/Serilog.Sinks.AzureTableStorage/Sinks/AzureTableStorageWithProperties/AzureTableStorageWithPropertiesSink.cs
@@ -18,6 +18,7 @@ using Microsoft.WindowsAzure.Storage;
 using Microsoft.WindowsAzure.Storage.Table;
 using Serilog.Core;
 using Serilog.Events;
+using Serilog.Sinks.AzureTableStorage.AzureTableProvider;
 using Serilog.Sinks.AzureTableStorage.KeyGenerator;
 using Serilog.Sinks.AzureTableStorage.Sinks.KeyGenerator;
 
@@ -30,10 +31,10 @@ namespace Serilog.Sinks.AzureTableStorage
     {
         private readonly int _waitTimeoutMilliseconds = Timeout.Infinite;
         private readonly IFormatProvider _formatProvider;
-        private readonly CloudTable _table;
         private readonly string _additionalRowKeyPostfix;
         private readonly string[] _propertyColumns;
         private readonly IKeyGenerator _keyGenerator;
+        private readonly ICloudTableProvider _cloudTableProvider;
 
         /// <summary>
         /// Construct a sink that saves logs to the specified storage account.
@@ -45,13 +46,15 @@ namespace Serilog.Sinks.AzureTableStorage
         /// <param name="keyGenerator">Generates the PartitionKey and the RowKey</param>
         /// <param name="propertyColumns">Specific properties to be written to columns. By default, all properties will be written to columns.</param>
         /// <param name="bypassTableCreationValidation">Bypass the exception in case the table creation fails.</param>
+        /// <param name="rollOnDateChange">Roll on to create new table on date change.</param>
         public AzureTableStorageWithPropertiesSink(CloudStorageAccount storageAccount,
             IFormatProvider formatProvider,
             string storageTableName = null,
             string additionalRowKeyPostfix = null,
             IKeyGenerator keyGenerator = null,
             string[] propertyColumns = null,
-            bool bypassTableCreationValidation = false)
+            bool bypassTableCreationValidation = false,
+            bool rollOnDateChange = false)
         {
             var tableClient = storageAccount.CreateCloudTableClient();
 
@@ -59,21 +62,7 @@ namespace Serilog.Sinks.AzureTableStorage
             {
                 storageTableName = "LogEventEntity";
             }
-
-            _table = tableClient.GetTableReference(storageTableName);
-
-            try
-            {
-                _table.CreateIfNotExistsAsync().SyncContextSafeWait(_waitTimeoutMilliseconds);
-            }
-            catch (Exception ex)
-            {
-                Debugging.SelfLog.WriteLine($"Failed to create table: {ex}");
-                if (!bypassTableCreationValidation)
-                {
-                    throw;
-                }
-            }
+            _cloudTableProvider = rollOnDateChange ? null : new DefaultCloudTableProvider(storageAccount, storageTableName, bypassTableCreationValidation);
 
             _formatProvider = formatProvider;
             _additionalRowKeyPostfix = additionalRowKeyPostfix;
@@ -87,9 +76,10 @@ namespace Serilog.Sinks.AzureTableStorage
         /// <param name="logEvent">The log event to write.</param>
         public void Emit(LogEvent logEvent)
         {
+            var table = _cloudTableProvider.GetCloudTable();
             var op = TableOperation.Insert(AzureTableStorageEntityFactory.CreateEntityWithProperties(logEvent, _formatProvider, _additionalRowKeyPostfix, _keyGenerator, _propertyColumns));
 
-            _table.ExecuteAsync(op).SyncContextSafeWait(_waitTimeoutMilliseconds);
+            table.ExecuteAsync(op).SyncContextSafeWait(_waitTimeoutMilliseconds);
         }
     }
 }


### PR DESCRIPTION
Added parameter rollOnDateChange to AzureTableStorageSink to create a new table every day postfixed with Ticks for current date. We at WorldRemit need to pull a lot of data from log table to splunk and splunk at the moment cannot handle data once records exceed more than a million records hence need to break down the log data set.