### PR TITLE
Updated ICloudTableProvider interface to include all required properties as parameters

### DIFF
--- a/src/Serilog.Sinks.AzureTableStorage/LoggerConfigurationAzureTableStorageExtensions.cs
+++ b/src/Serilog.Sinks.AzureTableStorage/LoggerConfigurationAzureTableStorageExtensions.cs
@@ -20,7 +20,6 @@ using Serilog.Core;
 using Serilog.Events;
 using Serilog.Sinks.AzureTableStorage;
 using Serilog.Sinks.AzureTableStorage.KeyGenerator;
-using Microsoft.WindowsAzure.Storage.Auth;
 using Serilog.Sinks.AzureTableStorage.AzureTableProvider;
 
 namespace Serilog

--- a/src/Serilog.Sinks.AzureTableStorage/LoggerConfigurationAzureTableStorageWithPropertiesExtensions.cs
+++ b/src/Serilog.Sinks.AzureTableStorage/LoggerConfigurationAzureTableStorageWithPropertiesExtensions.cs
@@ -20,7 +20,6 @@ using Serilog.Core;
 using Serilog.Events;
 using Serilog.Sinks.AzureTableStorage;
 using Serilog.Sinks.AzureTableStorage.KeyGenerator;
-using Microsoft.WindowsAzure.Storage.Auth;
 using Serilog.Sinks.AzureTableStorage.AzureTableProvider;
 
 namespace Serilog

--- a/src/Serilog.Sinks.AzureTableStorage/Sinks/AzureTableProvider/DefaultCloudTableProvider.cs
+++ b/src/Serilog.Sinks.AzureTableStorage/Sinks/AzureTableProvider/DefaultCloudTableProvider.cs
@@ -22,23 +22,14 @@ namespace Serilog.Sinks.AzureTableStorage.AzureTableProvider
     class DefaultCloudTableProvider : ICloudTableProvider
     {
         readonly int _waitTimeoutMilliseconds = Timeout.Infinite;
-        readonly string _storageTableName;
-        readonly bool _bypassTableCreationValidation;
         CloudTable _cloudTable;
 
-        public DefaultCloudTableProvider(string storageTableName,
-                                         bool bypassTableCreationValidation)
-        {
-            _storageTableName = storageTableName;
-            _bypassTableCreationValidation = bypassTableCreationValidation;
-        }
-
-        public CloudTable GetCloudTable(CloudStorageAccount storageAccount)
+        public CloudTable GetCloudTable(CloudStorageAccount storageAccount, string storageTableName, bool bypassTableCreationValidation)
         {
             if (_cloudTable == null)
             {
                 var cloudTableClient = storageAccount.CreateCloudTableClient();
-                _cloudTable = cloudTableClient.GetTableReference(_storageTableName);
+                _cloudTable = cloudTableClient.GetTableReference(storageTableName);
 
                 // In some cases (e.g.: SAS URI), we might not have enough permissions to create the table if
                 // it does not already exists. So, if we are in that case, we ignore the error as per bypassTableCreationValidation.
@@ -49,7 +40,7 @@ namespace Serilog.Sinks.AzureTableStorage.AzureTableProvider
                 catch (Exception ex)
                 {
                     Debugging.SelfLog.WriteLine($"Failed to create table: {ex}");
-                    if (!_bypassTableCreationValidation)
+                    if (!bypassTableCreationValidation)
                     {
                         throw;
                     }

--- a/src/Serilog.Sinks.AzureTableStorage/Sinks/AzureTableProvider/ICloudTableProvider.cs
+++ b/src/Serilog.Sinks.AzureTableStorage/Sinks/AzureTableProvider/ICloudTableProvider.cs
@@ -19,6 +19,6 @@ namespace Serilog.Sinks.AzureTableStorage.AzureTableProvider
 {
     public interface ICloudTableProvider
     {
-        CloudTable GetCloudTable(CloudStorageAccount storageAccount);
+        CloudTable GetCloudTable(CloudStorageAccount storageAccount, string storageTableName, bool bypassTableCreationValidation);
     }
 }

--- a/src/Serilog.Sinks.AzureTableStorage/Sinks/AzureTableStorage/AzureTableStorageSink.cs
+++ b/src/Serilog.Sinks.AzureTableStorage/Sinks/AzureTableStorage/AzureTableStorageSink.cs
@@ -32,6 +32,8 @@ namespace Serilog.Sinks.AzureTableStorage
         readonly IFormatProvider _formatProvider;
         readonly IKeyGenerator _keyGenerator;
         readonly CloudStorageAccount _storageAccount;
+        readonly string _storageTableName;
+        readonly bool _bypassTableCreationValidation;
         readonly ICloudTableProvider _cloudTableProvider;
 
         /// <summary>
@@ -60,7 +62,9 @@ namespace Serilog.Sinks.AzureTableStorage
             }
 
             _storageAccount = storageAccount;
-            _cloudTableProvider = cloudTableProvider ?? new DefaultCloudTableProvider(storageTableName, bypassTableCreationValidation);
+            _storageTableName = storageTableName;
+            _bypassTableCreationValidation = bypassTableCreationValidation;
+            _cloudTableProvider = cloudTableProvider ?? new DefaultCloudTableProvider();
         }
 
         /// <summary>
@@ -69,7 +73,7 @@ namespace Serilog.Sinks.AzureTableStorage
         /// <param name="logEvent">The log event to write.</param>
         public void Emit(LogEvent logEvent)
         {
-            var table = _cloudTableProvider.GetCloudTable(_storageAccount);
+            var table = _cloudTableProvider.GetCloudTable(_storageAccount, _storageTableName, _bypassTableCreationValidation);
             var logEventEntity = new LogEventEntity(
                 logEvent,
                 _formatProvider,


### PR DESCRIPTION
This would allow to specify any other table provider through configuration as well (specifying type in configuration requires the type has a parameterless constructor).