### PR TITLE
Update LogEventEntity TimeStamp to use the right type

### DIFF
--- a/src/Serilog.Sinks.AzureTableStorage/Sinks/AzureTableStorage/LogEventEntity.cs
+++ b/src/Serilog.Sinks.AzureTableStorage/Sinks/AzureTableStorage/LogEventEntity.cs
@@ -44,7 +44,7 @@ namespace Serilog.Sinks.AzureTableStorage
             string partitionKey,
             string rowKey)
         {
-            Timestamp = log.Timestamp.ToUniversalTime().DateTime;
+            Timestamp = log.Timestamp.ToUniversalTime();
             PartitionKey = partitionKey;
             RowKey = GetValidRowKey(rowKey);
             MessageTemplate = log.MessageTemplate.Text;


### PR DESCRIPTION
Fix Serializing OffsetDateTime when using NodaTime API