### PR TITLE
Fixes #54 Adds ITextFormatter support

### DIFF
--- a/src/Serilog.Sinks.AzureTableStorage/Serilog.Sinks.AzureTableStorage.csproj
+++ b/src/Serilog.Sinks.AzureTableStorage/Serilog.Sinks.AzureTableStorage.csproj
@@ -22,6 +22,7 @@
 
   <ItemGroup>
     <PackageReference Include="Serilog" Version="2.6.0" />
+    <PackageReference Include="Serilog.Formatting.Compact" Version="1.0.0" />
     <PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="2.1.1" />
     <PackageReference Include="WindowsAzure.Storage" Version="9.1.0" />
   </ItemGroup>

--- a/src/Serilog.Sinks.AzureTableStorage/Sinks/AzureTableStorage/AzureBatchingTableStorageSink.cs
+++ b/src/Serilog.Sinks.AzureTableStorage/Sinks/AzureTableStorage/AzureBatchingTableStorageSink.cs
@@ -23,6 +23,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Serilog.Formatting;
 
 namespace Serilog.Sinks.AzureTableStorage
 {
@@ -33,6 +34,7 @@ namespace Serilog.Sinks.AzureTableStorage
     {
         readonly int _waitTimeoutMilliseconds = Timeout.Infinite;
         readonly IFormatProvider _formatProvider;
+        readonly ITextFormatter _textFormatter;
         readonly IKeyGenerator _keyGenerator;
         readonly CloudStorageAccount _storageAccount;
         readonly ICloudTableProvider _cloudTableProvider;
@@ -49,11 +51,12 @@ namespace Serilog.Sinks.AzureTableStorage
         public AzureBatchingTableStorageSink(
             CloudStorageAccount storageAccount,
             IFormatProvider formatProvider,
+            ITextFormatter textFormatter,
             int batchSizeLimit,
             TimeSpan period,
             string storageTableName = null,
             ICloudTableProvider cloudTableProvider = null)
-            : this(storageAccount, formatProvider, batchSizeLimit, period, storageTableName, new DefaultKeyGenerator(), cloudTableProvider: cloudTableProvider)
+            : this(storageAccount, formatProvider, textFormatter, batchSizeLimit, period, storageTableName, new DefaultKeyGenerator(), cloudTableProvider: cloudTableProvider)
         {
         }
 
@@ -62,6 +65,7 @@ namespace Serilog.Sinks.AzureTableStorage
         /// </summary>
         /// <param name="storageAccount">The Cloud Storage Account to use to insert the log entries to.</param>
         /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
+        /// <param name="textFormatter"></param>
         /// <param name="batchSizeLimit"></param>
         /// <param name="period"></param>
         /// <param name="storageTableName">Table name that log entries will be written to. Note: Optional, setting this may impact performance</param>
@@ -71,6 +75,7 @@ namespace Serilog.Sinks.AzureTableStorage
         public AzureBatchingTableStorageSink(
             CloudStorageAccount storageAccount,
             IFormatProvider formatProvider,
+            ITextFormatter textFormatter,
             int batchSizeLimit,
             TimeSpan period,
             string storageTableName = null,
@@ -83,6 +88,7 @@ namespace Serilog.Sinks.AzureTableStorage
                 throw new ArgumentException("batchSizeLimit must be between 1 and 100 for Azure Table Storage");
 
             _formatProvider = formatProvider;
+            _textFormatter = textFormatter;
             _keyGenerator = keyGenerator ?? new DefaultKeyGenerator();
 
             if (string.IsNullOrEmpty(storageTableName))
@@ -117,6 +123,7 @@ namespace Serilog.Sinks.AzureTableStorage
                 var logEventEntity = new LogEventEntity(
                     logEvent,
                     _formatProvider,
+                    _textFormatter,
                     partitionKey,
                     _keyGenerator.GenerateRowKey(logEvent)
                     );

--- a/src/Serilog.Sinks.AzureTableStorage/Sinks/AzureTableStorage/AzureTableStorageSink.cs
+++ b/src/Serilog.Sinks.AzureTableStorage/Sinks/AzureTableStorage/AzureTableStorageSink.cs
@@ -18,6 +18,7 @@ using Microsoft.WindowsAzure.Storage;
 using Microsoft.WindowsAzure.Storage.Table;
 using Serilog.Core;
 using Serilog.Events;
+using Serilog.Formatting;
 using Serilog.Sinks.AzureTableStorage.AzureTableProvider;
 using Serilog.Sinks.AzureTableStorage.KeyGenerator;
 
@@ -30,6 +31,7 @@ namespace Serilog.Sinks.AzureTableStorage
     {
         readonly int _waitTimeoutMilliseconds = Timeout.Infinite;
         readonly IFormatProvider _formatProvider;
+        readonly ITextFormatter _textFormatter;
         readonly IKeyGenerator _keyGenerator;
         readonly CloudStorageAccount _storageAccount;
         readonly ICloudTableProvider _cloudTableProvider;
@@ -38,7 +40,7 @@ namespace Serilog.Sinks.AzureTableStorage
         /// Construct a sink that saves logs to the specified storage account.
         /// </summary>
         /// <param name="storageAccount">The Cloud Storage Account to use to insert the log entries to.</param>
-        /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
+        /// <param name="textFormatter"></param>
         /// <param name="storageTableName">Table name that log entries will be written to. Note: Optional, setting this may impact performance</param>
         /// <param name="keyGenerator">generator used to generate partition keys and row keys</param>
         /// <param name="bypassTableCreationValidation">Bypass the exception in case the table creation fails.</param>
@@ -46,12 +48,14 @@ namespace Serilog.Sinks.AzureTableStorage
         public AzureTableStorageSink(
             CloudStorageAccount storageAccount,
             IFormatProvider formatProvider,
+            ITextFormatter textFormatter,
             string storageTableName = null,
             IKeyGenerator keyGenerator = null,
             bool bypassTableCreationValidation = false,
             ICloudTableProvider cloudTableProvider = null)
         {
             _formatProvider = formatProvider;
+            _textFormatter = textFormatter;
             _keyGenerator = keyGenerator ?? new DefaultKeyGenerator();
 
             if (string.IsNullOrEmpty(storageTableName))
@@ -73,6 +77,7 @@ namespace Serilog.Sinks.AzureTableStorage
             var logEventEntity = new LogEventEntity(
                 logEvent,
                 _formatProvider,
+                _textFormatter,
                 _keyGenerator.GeneratePartitionKey(logEvent),
                 _keyGenerator.GenerateRowKey(logEvent)
                 );

--- a/src/Serilog.Sinks.AzureTableStorage/Sinks/AzureTableStorage/LogEventEntity.cs
+++ b/src/Serilog.Sinks.AzureTableStorage/Sinks/AzureTableStorage/LogEventEntity.cs
@@ -16,7 +16,7 @@ using System;
 using System.IO;
 using Microsoft.WindowsAzure.Storage.Table;
 using Serilog.Events;
-using Serilog.Formatting.Json;
+using Serilog.Formatting;
 
 namespace Serilog.Sinks.AzureTableStorage
 {
@@ -35,12 +35,14 @@ namespace Serilog.Sinks.AzureTableStorage
         /// Create a log event entity from a Serilog <see cref="LogEvent"/>.
         /// </summary>
         /// <param name="log">The event to log</param>
-        /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
+        /// <param name="formatProvider"></param>
+        /// <param name="textFormatter"></param>
         /// <param name="partitionKey">partition key to store</param>
         /// <param name="rowKey">row key to store</param>
         public LogEventEntity(
             LogEvent log,
             IFormatProvider formatProvider,
+            ITextFormatter textFormatter,
             string partitionKey,
             string rowKey)
         {
@@ -51,8 +53,10 @@ namespace Serilog.Sinks.AzureTableStorage
             Level = log.Level.ToString();
             Exception = log.Exception?.ToString();
             RenderedMessage = log.RenderMessage(formatProvider);
+
+            //Use the underlying TextFormatter to serialise the entire JSON object for the data column
             var s = new StringWriter();
-            new JsonFormatter(closingDelimiter: "", formatProvider: formatProvider).Format(log, s);
+            textFormatter.Format(log, s);
             Data = s.ToString();
         }
 


### PR DESCRIPTION
This PR adds in ITextFormatter and uses the default `CompactJsonFormatter` as opposed to the older `JsonFormatter` when serilalizing the object into the Data column