### PR TITLE
Updated the tableoperation to InsertOrMerge

### DIFF
--- a/src/Serilog.Sinks.AzureTableStorage/Serilog.Sinks.AzureTableStorage.csproj
+++ b/src/Serilog.Sinks.AzureTableStorage/Serilog.Sinks.AzureTableStorage.csproj
@@ -18,6 +18,7 @@
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
     <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
+    <AutoGenerateBindingRedirects>True</AutoGenerateBindingRedirects>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Serilog.Sinks.AzureTableStorage/Serilog.Sinks.AzureTableStorage.csproj
+++ b/src/Serilog.Sinks.AzureTableStorage/Serilog.Sinks.AzureTableStorage.csproj
@@ -18,7 +18,6 @@
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
     <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
-    <AutoGenerateBindingRedirects>True</AutoGenerateBindingRedirects>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Serilog.Sinks.AzureTableStorage/Sinks/AzureTableStorage/AzureBatchingTableStorageSink.cs
+++ b/src/Serilog.Sinks.AzureTableStorage/Sinks/AzureTableStorage/AzureBatchingTableStorageSink.cs
@@ -122,7 +122,7 @@ namespace Serilog.Sinks.AzureTableStorage
                     partitionKey,
                     _keyGenerator.GenerateRowKey(logEvent)
                     );
-                operation.Add(TableOperation.Insert(logEventEntity));
+                operation.Add(TableOperation.InsertOrMerge(logEventEntity));
             }
             if (operation.Count > 0)
             {

--- a/src/Serilog.Sinks.AzureTableStorage/Sinks/AzureTableStorage/AzureTableStorageSink.cs
+++ b/src/Serilog.Sinks.AzureTableStorage/Sinks/AzureTableStorage/AzureTableStorageSink.cs
@@ -81,7 +81,7 @@ namespace Serilog.Sinks.AzureTableStorage
                 _keyGenerator.GenerateRowKey(logEvent)
                 );
 
-            table.ExecuteAsync(TableOperation.Insert(logEventEntity))
+            table.ExecuteAsync(TableOperation.InsertOrMerge(logEventEntity))
                 .SyncContextSafeWait(_waitTimeoutMilliseconds);
         }
     }

--- a/src/Serilog.Sinks.AzureTableStorage/Sinks/AzureTableStorageWithProperties/AzureBatchingTableStorageWithPropertiesSink.cs
+++ b/src/Serilog.Sinks.AzureTableStorage/Sinks/AzureTableStorageWithProperties/AzureBatchingTableStorageWithPropertiesSink.cs
@@ -118,7 +118,7 @@ namespace Serilog.Sinks.AzureTableStorage
                 }
 
                 // Add current entry to the batch
-                operation.Add(TableOperation.Insert(tableEntity));
+                operation.Add(TableOperation.InsertOrMerge(tableEntity));
 
                 insertsPerOperation++;
             }

--- a/src/Serilog.Sinks.AzureTableStorage/Sinks/AzureTableStorageWithProperties/AzureTableStorageWithPropertiesSink.cs
+++ b/src/Serilog.Sinks.AzureTableStorage/Sinks/AzureTableStorageWithProperties/AzureTableStorageWithPropertiesSink.cs
@@ -82,7 +82,7 @@ namespace Serilog.Sinks.AzureTableStorage
         public void Emit(LogEvent logEvent)
         {
             var table = _cloudTableProvider.GetCloudTable(_storageAccount, _storageTableName, _bypassTableCreationValidation);
-            var op = TableOperation.Insert(AzureTableStorageEntityFactory.CreateEntityWithProperties(logEvent, _formatProvider, _additionalRowKeyPostfix, _keyGenerator, _propertyColumns));
+            var op = TableOperation.InsertOrMerge(AzureTableStorageEntityFactory.CreateEntityWithProperties(logEvent, _formatProvider, _additionalRowKeyPostfix, _keyGenerator, _propertyColumns));
 
             table.ExecuteAsync(op).SyncContextSafeWait(_waitTimeoutMilliseconds);
         }

--- a/src/Serilog.Sinks.AzureTableStorage/Sinks/KeyGenerator/PropertiesKeyGenerator.cs
+++ b/src/Serilog.Sinks.AzureTableStorage/Sinks/KeyGenerator/PropertiesKeyGenerator.cs
@@ -52,7 +52,6 @@ namespace Serilog.Sinks.AzureTableStorage.Sinks.KeyGenerator
             {
                 prefixBuilder.Length = maxPrefixLength;
             }
-
             return prefixBuilder.Append(postfixBuilder).ToString();
         }
     }

--- a/test/Serilog.Sinks.AzureTableStorageWithProperties.Tests/AzureTableStorageWithPropertiesSinkTests.cs
+++ b/test/Serilog.Sinks.AzureTableStorageWithProperties.Tests/AzureTableStorageWithPropertiesSinkTests.cs
@@ -474,7 +474,7 @@ namespace Serilog.Sinks.AzureTableStorage.Tests
                 policy = new SharedAccessTablePolicy()
                 {
                     SharedAccessExpiryTime = DateTime.UtcNow.AddHours(48),
-                    Permissions = SharedAccessTablePermissions.Add
+                    Permissions = SharedAccessTablePermissions.Add | SharedAccessTablePermissions.Update
                 };
                 permissions.SharedAccessPolicies.Add(PolicyName, policy);
             }


### PR DESCRIPTION
Updated the tableoperation to InsertOrMerge, so you can update entries when using calculated partition and rowkeys.

